### PR TITLE
Prime Artifacts migration, structured log, and hardening sweep 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 回覆語言規範（必要）
+
+在本專案中，所有對使用者的回覆都必須使用**繁體中文**。唯一例外是**專有名詞**，包含但不限於：
+- 產品／工具名稱（Harbor、RKE2、Rancher、Neuvector、K3S、Helm、cert-manager、Docker、Podman、Kubernetes 等）
+- 指令、旗標、環境變數、檔案／路徑名稱（例如 `prepare.sh`、`${Harbor_Version}`、`~/work/`）
+- 程式碼片段、錯誤訊息、API 名稱、程式語言關鍵字
+
+所有說明性文字、敘述、提問與摘要一律使用繁體中文（不得使用簡體中文或英文）。
+
+## GitOps 原則（所有變更都必須遵守）
+
+本專案視 Git 為**唯一真實來源**（single source of truth）。任何對檔案或腳本的修改都必須符合以下原則，否則請拒絕或先與使用者確認：
+
+1. **所有變更走 Git。** 不在本機或 `~/work/` 下做「暫時的」手動修改；要改 `prepare.sh`／`podman-prepare.sh`／`README.md`／`CLAUDE.md` 或任何設定，都透過檔案編輯 → `git commit` → （必要時）`git push` 的流程。拒絕產生不進版控的「補丁輸出」。
+2. **宣告式、可重現。** 給定相同的環境變數（版本、`Private_Registry_Name` 等）與相同的 commit，執行結果的產物（`~/work/compressed_files/*.tar.gz` 的內容）應該可以重現。因此：
+   - **版本必須 pin 成具體值**，不得引入 `latest`、floating tag、或「最新 release」這類動態解析。
+   - 新增外部資源時，URL 必須是可版本化的 release 連結，不得指向會變動的分支／HEAD。
+3. **兩支腳本同步在同一 commit。** `prepare.sh` 與 `podman-prepare.sh` 是平行孿生腳本；任一行為修改都必須在**同一個 commit**內同時更新兩支，避免 drift。若只改其中一支，視為違反 GitOps 原則，需要明確理由並寫在 commit message 中。
+4. **預設值四處同步。** 修改某個預設版本時，兩支腳本的 `setup_env` 內與 `usage` heredoc 內共四處必須一起改，並在同一個 commit 落地（見下方「架構」一節）。
+5. **冪等。** 腳本執行可安全重跑；編輯腳本時請維持這個性質（目錄用 `mkdir -p`、下載允許覆寫既有檔案等）。不要引入「只能跑一次」或會污染使用者既有狀態的步驟。
+6. **Commit 訊息描述 why，而不只是 what。** 版本升級要註明上游 release，行為改動要註明動機，方便日後從 `git log` 重建決策脈絡。
+7. **不要提交產出物（artifact）與 log。** `~/work/`、`/tmp/prepare_*.log`、任何 `*.tar.gz` 都是執行產物，不屬於 Git 倉庫。
+8. **不要修改 git 設定、不要 force push、不要 `--no-verify`。** 如有衝突，先跟使用者確認再處理。
+
+以上原則對「文件更新」同樣適用——`README.md` 與 `CLAUDE.md` 的修改也必須透過 commit 落地，並在訊息中說明原因。
+
+## 專案目的
+
+本專案包含兩支幾乎完全相同的 Bash 腳本，用於打包 Harbor、RKE2、Rancher（Prime）、K3S 與 Neuvector 的全離線（air-gap）安裝包。每次執行會下載該產品的 release 檔案，並把所需的 container images 全部拉下來，最後用 tar + gzip 壓縮成 `~/work/compressed_files/<product>-airgap-<version>.tar.gz`。
+
+## 執行方式
+
+```bash
+./prepare.sh        <target>...   # 使用 docker（需可免密碼 sudo）
+./podman-prepare.sh <target>...   # 使用 rootless podman
+```
+
+可用的 target：`all` | `harbor` | `rke2` | `rancher` | `neuvector` | `k3s`。不帶參數時會印出 usage。
+
+版本可透過 `README.md` 列出的環境變數覆寫（`Harbor_Version`、`RKE2_Version`、`Rancher_Version`、`K3S_Version`、`Neuvector_Version`、`Helm_Version`、`Cert_Manager_Version`、`Docker_Compose_Version`、`Private_Registry_Name`）。本專案沒有 build／lint／test 工具鏈，單純就是 shell 腳本，沒有對應的測試 harness。
+
+Log：每一條執行的指令都會透過 `BASH_XTRACEFD` + `set -x` 寫進 `/tmp/prepare_message.log`；下載／pull 的 stdout/stderr 則寫進 `/tmp/prepare_output_message.log`。這兩個檔案會在每次執行開頭被刪除。
+
+## 架構
+
+**兩支腳本、一套邏輯。** `prepare.sh` 與 `podman-prepare.sh` 幾乎逐行對應——差異只在 container runtime（`sudo docker` vs rootless `podman`，以及 `podman save -m` 用於多 image save）。**任何行為上的修改，通常都必須在兩支腳本裡都改一次。** 除非某個改動本質上只跟單一 runtime 有關，否則請同步維護。
+
+**每個 target 的處理流程。** 每個 `prepare_<product>()` 函式會：
+1. 呼叫 `setup_env`（檢查網路、用 `nc`/`which` 檢查工具、為缺少的版本變數填入預設值）。
+2. `cd ~/work/<product>/<version>`（目錄由 `create_working_directory` 建立）。
+3. 用 `wget`／`curl` 從上游下載 release 資產（GitHub releases、`get.helm.sh`、`get.rke2.io`、`get.k3s.io`，以及 rancher／jetstack／neuvector 的 Helm repo）。
+4. 對於以 Helm chart 形式發佈的產品（rancher、cert-manager、neuvector）：先 `helm template` 渲染 chart，用 grep 抓出 `image:` 行，逐一 pull，再 retag 為 `${Private_Registry_Name}/rancher/...`，最後以 `docker/podman save | gzip` 打包成單一的 `*.tar.gz`。
+5. `tar -czf ~/work/compressed_files/<product>-airgap-<version>.tar.gz <product>/<version>`。
+
+**Dispatch。** 檔案尾端的 `while`／`case` 迴圈把每個位置參數導向 `create_working_directory` + `prepare_<x>`。注意 `all` **只會**跑 harbor + rke2 + rancher（不含 k3s／neuvector），而且執行完會 `exit 0`——它不會跟同一行上其他的參數串接執行。
+
+**setup_env 的預設值。** 預設版本同時寫在 `setup_env` 內，也重複寫在 `usage` 的 heredoc 裡。想改某個預設版本，代表兩支腳本、各兩處，總共要改**四個地方**。
+
+## 已知的粗糙之處（不要無腦「修」）
+
+- `prepare.sh` 大約第 320 行：`"{K3S_Version}"` 漏了開頭的 `$`。這是 docker 腳本裡真實存在的 bug；`podman-prepare.sh` 這行是對的。
+- 有多處錯誤檢查寫成：在一條 pipeline 的**下一行**用 `[[ "$?" != "0" ]] && echo ... && exit 1`——但 `$?` 只反映 pipeline 最後一個指令的狀態，無法捕捉前段指令的失敗。除非使用者明確要求強化錯誤處理，否則保留現狀。
+- 程式碼註解與使用者面向的訊息都是繁體中文，編修時請沿用這個慣例。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,12 +56,11 @@ Log：每一條執行的指令都會透過 `BASH_XTRACEFD` + `set -x` 寫進 `/t
 4. 對於以 Helm chart 形式發佈的產品（rancher、cert-manager、neuvector）：先 `helm template` 渲染 chart，用 grep 抓出 `image:` 行，逐一 pull，再 retag 為 `${Private_Registry_Name}/rancher/...`，最後以 `docker/podman save | gzip` 打包成單一的 `*.tar.gz`。
 5. `tar -czf ~/work/compressed_files/<product>-airgap-<version>.tar.gz <product>/<version>`。
 
-**Dispatch。** 檔案尾端的 `while`／`case` 迴圈把每個位置參數導向 `create_working_directory` + `prepare_<x>`。注意 `all` **只會**跑 harbor + rke2 + rancher（不含 k3s／neuvector），而且執行完會 `exit 0`——它不會跟同一行上其他的參數串接執行。
+**Dispatch。** 檔案尾端的 `while`／`case` 迴圈把每個位置參數導向 `create_working_directory` + `prepare_<x>`，所有呼叫都透過 `run_step` helper：它把 stdout/stderr tee 到 `Command_Output_log_file`，並用 `PIPESTATUS[0]` 取 pipeline 第一段的 exit code，確保 function 內 `exit N` 能正確終止整支腳本（避免 pipeline subshell 吞掉 exit code）。`all` 會依序跑所有五個產品（harbor → rke2 → rancher → k3s → neuvector）後 `exit 0`，**不會**再回到 dispatch loop 處理同一行其餘參數。
 
 **setup_env 的預設值。** 預設版本同時寫在 `setup_env` 內，也重複寫在 `usage` 的 heredoc 裡。想改某個預設版本，代表兩支腳本、各兩處，總共要改**四個地方**。
 
 ## 已知的粗糙之處（不要無腦「修」）
 
-- `prepare.sh` 大約第 320 行：`"{K3S_Version}"` 漏了開頭的 `$`。這是 docker 腳本裡真實存在的 bug；`podman-prepare.sh` 這行是對的。
-- 有多處錯誤檢查寫成：在一條 pipeline 的**下一行**用 `[[ "$?" != "0" ]] && echo ... && exit 1`——但 `$?` 只反映 pipeline 最後一個指令的狀態，無法捕捉前段指令的失敗。除非使用者明確要求強化錯誤處理，否則保留現狀。
+- `prepare_*` 函式內部仍有若干 `[[ "$?" != "0" ]] && echo ... && exit 1` 寫在一條 pipeline 的**下一行**——`$?` 只反映 pipeline 最後一個指令的狀態（例：`... | gzip > file.tar.gz` 成功但前段 `helm template` 或 `docker save` 失敗會被吞）。dispatch 層已透過 `run_step` + `PIPESTATUS[0]` 守住；內部這些檢查除非使用者明確要求強化，否則保留。
 - 程式碼註解與使用者面向的訊息都是繁體中文，編修時請沿用這個慣例。

--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@
 可自動化準備指定的產品及對應的版本，包含 Harbor、Rancher Kubernetes Engine 2 ( RKE2 )、Rancher、Neuvector 和 K3S 全離線安裝所需的檔案和 Container Images。
 全離線安裝所需的檔案和 Container Images 會被壓縮成一個壓縮檔，並儲存在 `~/work/compressed_files` 目錄底下。
 
+Rancher 生態系的 artifact（RKE2／Rancher／K3S）預設從 **Rancher Prime Artifacts**（`https://prime.ribs.rancher.io`）取得，可透過對應的 `*_Source_URL` 環境變數覆寫來源。
+
 ## PreRequirements
 
 ### prepare.sh
 - Packages:
   - curl
   - wget
+  - nc (netcat，連線檢查用)
   - docker
   - sudo (without password)
 
@@ -18,6 +21,7 @@
 - Packages:
   - curl
   - wget
+  - nc (netcat，連線檢查用)
   - podman (rootless)
   - sudo (without password)
 
@@ -33,15 +37,21 @@ chmod +x *.sh
 
 ### 開始執行
 
-```
-./podman-prepare.sh harbor rke2 k3s neuvector
-```
-
-螢幕輸出 : 
+`all` 會依序準備五個產品（harbor → rke2 → rancher → k3s → neuvector）：
 
 ```
+./podman-prepare.sh all
+```
+
+螢幕輸出範例（image pull 過程會在**同一行**即時更新進度列，最終留下各產品完成訊息）：
+
+```
+[cert-manager 11/11] quay.io/jetstack/cert-manager-ctl:v1.11.0
+[rancher 127/127] rancher/mirrored-coredns-coredns:1.12.0
+[neuvector 8/8] neuvector/scanner:latest
 Prepare Harbor v2.15.0 OK.
 Prepare RKE2 v1.35.3 OK.
+Prepare Rancher v2.13.4 OK.
 Prepare K3S v1.35.3 OK.
 Prepare Neuvector 5.5.0 OK.
 ```
@@ -50,12 +60,15 @@ Prepare Neuvector 5.5.0 OK.
 
 ```
 $ ls -lh ~/work/compressed_files/
-total 1.9G
--rw-r--r-- 1 bigred bigred 630M Mar 15 15:15 harbor-offline-v2.15.0.tar.gz
--rw-r--r-- 1 bigred bigred 192M Mar 15 15:17 k3s-airgap-v1.35.3.tar.gz
--rw-r--r-- 1 bigred bigred  91M Mar 15 15:18 neuvector-airgap-5.5.0.tar.gz
--rw-r--r-- 1 bigred bigred 956M Mar 15 15:17 rke2-airgap-v1.35.3.tar.gz
+total 2.5G
+-rw-r--r-- 1 bigred bigred 661M Apr 21 13:35 harbor-offline-v2.15.0.tar.gz
+-rw-r--r-- 1 bigred bigred 192M Apr 21 13:40 k3s-airgap-v1.35.3.tar.gz
+-rw-r--r-- 1 bigred bigred  91M Apr 21 13:45 neuvector-airgap-5.5.0.tar.gz
+-rw-r--r-- 1 bigred bigred 705M Apr 21 13:50 rancher-airgap-v2.13.4.tar.gz
+-rw-r--r-- 1 bigred bigred 956M Apr 21 13:55 rke2-airgap-v1.35.3.tar.gz
 ```
+
+> 每次執行 `prepare_<product>` 會先 `rm -f ~/work/compressed_files/<product>-*.tar.gz`，同產品舊版本 tarball 會被覆蓋；不同產品互不影響。
 
 
 ## Usage
@@ -66,7 +79,7 @@ Usage:
 
 Available options:
 
-all        一次準備 Harbor、RKE2、Rancher 的全離線安裝包
+all        一次準備 Harbor、RKE2、Rancher、K3S、Neuvector 的全離線安裝包
 harbor     只準備 Harbor 的全離線安裝包
 rke2       只準備 RKE2 的全離線安裝包
 rancher    只準備 Rancher 的全離線安裝包
@@ -141,7 +154,7 @@ Environment variables:
 ```
 
 ## Example:
-  ### 一次準備 Harbor、RKE2、Rancher 的全離線安裝包，並且指定安裝 Harbor 特定版本
+  ### 一次準備全部五個產品（Harbor、RKE2、Rancher、K3S、Neuvector），並指定 Harbor 特定版本
   ```
   Harbor_Version=v2.7.0 ./podman-prepare.sh all
   ```
@@ -151,7 +164,7 @@ Environment variables:
   ```
   ### 準備 Neuvector 的全離線安裝包，並且指定安裝 Neuvector 5.2.0 版本
   ```
-  Neuvector_Version=5.2.0 ../podman-prepare.sh neuvector
+  Neuvector_Version=5.2.0 ./podman-prepare.sh neuvector
   ```
 
   ### 同時準備 Rancher、Harbor 和 K3S 的全離線安裝包，分別指定安裝 v2.7.9、v2.7.0 和 v1.25.9 版本，並設定私有 Image Registry 的名稱
@@ -159,6 +172,13 @@ Environment variables:
   Rancher_Version=v2.7.9 Harbor_Version=v2.7.0 K3S_Version=v1.25.9 \
   Private_Registry_Name="antony-harbor.example.com" \
   ./podman-prepare.sh rancher harbor k3s
+  ```
+
+  ### 覆寫 RKE2 來源 URL 與 revision（從 Prime Artifacts 換回 GitHub releases）
+  ```
+  RKE2_Source_URL=https://github.com/rancher/rke2/releases/download \
+  RKE2_Version=v1.27.11 RKE2_Revision=rke2r1 \
+  ./podman-prepare.sh rke2
   ```
 
 ## 範例目錄結構
@@ -183,16 +203,54 @@ Environment variables:
 ```
 
 ## Log
-### 檢視程式執行了哪些命令
+
+執行期間兩個 log 檔分工：
+
+### `/tmp/prepare_message.log`（xtrace，細節 debug 用）
+
+由 `set -x` + `BASH_XTRACEFD` 產出，每行帶時間戳與來源行號格式：
+```
++ [13:07:27] podman-prepare.sh:248: logged_run 'harbor: download offline-installer tgz' wget -nv -O harbor-offline-installer-v2.15.0.tgz https://...
+```
+
+### `/tmp/prepare_output_message.log`（合併結構化 log，日常看這個）
+
+每個外部命令（`wget`／`curl`／`helm`／`podman/docker pull|tag|save`／`tar`…）都由 `logged_run` 包裝，寫成 `=== [TS] <label> ===` → `CMD: ...` → raw output → `=== [TS] EXIT: <rc> ===` 的區塊；每個 `prepare_<product>` 函式的首尾另有 `############` 醒目分隔符標記 START／END：
 
 ```
+############################################################
+# [2026-04-21 13:07:27] prepare_harbor START (Harbor_Version=v2.15.0)
+############################################################
+
+=== [2026-04-21 13:07:27] harbor: download offline-installer tgz ===
+CMD: wget -nv -O harbor-offline-installer-v2.15.0.tgz https://github.com/goharbor/harbor/releases/download/v2.15.0/...
+2026-04-21 13:08:10 URL:https://release-assets.githubusercontent.com/... [671556546/671556546] -> "harbor-offline-installer-v2.15.0.tgz" [1]
+=== [2026-04-21 13:08:10] EXIT: 0 ===
+
+...
+
+############################################################
+# [2026-04-21 13:08:29] prepare_harbor END
+############################################################
+```
+
+進度列（例：`[rancher 42/127] <image>`）只印在終端（`/dev/tty`），**不**污染 log 檔。
+
+兩個檔案在每次執行開頭都會被刪除重建。
+
+```
+# 追蹤執行期間的結構化 log
+$ tail -f /tmp/prepare_output_message.log
+
+# 除錯用 xtrace
 $ tail -f /tmp/prepare_message.log
 ```
 
-### 檢視程式執行命令的執行結果
+## Helm 與 Kubernetes 版本相容性
 
-```
-$ tail -f /tmp/prepare_output_message.log
-```
+`setup_env` 會在執行任何 `prepare_*` 前做 pre-flight 檢查：若 `${Helm_Version}` compiled-against 的 Kubernetes 版本與 `${RKE2_Version}`／`${K3S_Version}` 不在 Helm 官方的 **n-3 support window** 內，會 exit 並印明確提示（該升哪個、該降哪個）。參見 <https://helm.sh/docs/topics/version_skew/>。
+
+規律（v3.x 系列）：Helm `3.N` 對應 Kubernetes `1.(N+15)`。
+- 預設 `Helm_Version=v3.20.2` → k8s 1.35 → 支援 1.32–1.35，預設 `v1.35.3` RKE2／K3S 相容。
 
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ chmod +x *.sh
 螢幕輸出 : 
 
 ```
-Prepare Harbor v2.10.0 OK.
-Prepare RKE2 v1.27.11 OK.
-Prepare K3S v1.27.11 OK.
-Prepare Neuvector 5.3.0 OK.
+Prepare Harbor v2.15.0 OK.
+Prepare RKE2 v1.35.3 OK.
+Prepare K3S v1.35.3 OK.
+Prepare Neuvector 5.5.0 OK.
 ```
 
 檢查全離線安裝包
@@ -51,10 +51,10 @@ Prepare Neuvector 5.3.0 OK.
 ```
 $ ls -lh ~/work/compressed_files/
 total 1.9G
--rw-r--r-- 1 bigred bigred 630M Mar 15 15:15 harbor-offline-v2.10.0.tar.gz
--rw-r--r-- 1 bigred bigred 192M Mar 15 15:17 k3s-airgap-v1.27.11.tar.gz
--rw-r--r-- 1 bigred bigred  91M Mar 15 15:18 neuvector-airgap-5.3.0.tar.gz
--rw-r--r-- 1 bigred bigred 956M Mar 15 15:17 rke2-airgap-v1.27.11.tar.gz
+-rw-r--r-- 1 bigred bigred 630M Mar 15 15:15 harbor-offline-v2.15.0.tar.gz
+-rw-r--r-- 1 bigred bigred 192M Mar 15 15:17 k3s-airgap-v1.35.3.tar.gz
+-rw-r--r-- 1 bigred bigred  91M Mar 15 15:18 neuvector-airgap-5.5.0.tar.gz
+-rw-r--r-- 1 bigred bigred 956M Mar 15 15:17 rke2-airgap-v1.35.3.tar.gz
 ```
 
 
@@ -77,19 +77,19 @@ Environment variables:
 
    - Harbor_Version
      定義 Harbor 的版本
-     預設是 'v2.10.0'。
+     預設是 'v2.15.0'。
 
    - Docker_Compose_Version
      定義 docker-compose 的版本
-     預設是 'v2.24.7'。
+     預設是 'v2.40.3'。
 
    - RKE2_Version
      定義 RKE2 的版本
-     預設是 'v1.27.11'。
+     預設是 'v1.35.3'。
 
    - RKE2_Revision
      定義 RKE2 的 revision 後綴
-     預設是 'rke2r1'。
+     預設是 'rke2r3'。
 
    - RKE2_Source_URL
      定義下載 RKE2 airgap artifact 的來源 URL
@@ -97,11 +97,11 @@ Environment variables:
 
    - Rancher_Version
      定義 Rancher 的版本
-     預設是 'v2.8.2'。
+     預設是 'v2.14.0'。
 
    - Helm_Version
      定義 Helm 的版本
-     預設是 'v3.14.2'。
+     預設是 'v3.20.2'。
 
    - Cert_Manager_Version
      定義 Cert-manager 的版本
@@ -109,11 +109,11 @@ Environment variables:
 
    - K3S_Version
      定義 K3S 的版本
-     預設是 'v1.27.11'。
+     預設是 'v1.35.3'。
 
    - Neuvector_Version
      定義 Neuvector 的版本
-     預設是 '5.3.0'。
+     預設是 '5.5.0'。
 
    - Private_Registry_Name
      定義企業內部私有 Image Registry 的名稱
@@ -153,21 +153,21 @@ Environment variables:
 ```
 ~/work/
 ├── compressed_files
-│   ├── harbor-offline-v2.10.0.tar.gz   --> Harbor v2.10.0 版本的全離線安裝包
-│   ├── k3s-airgap-v1.27.11.tar.gz      --> K3S v1.27.11 版本的全離線安裝包
-│   ├── neuvector-airgap-5.3.0.tar.gz   --> Neuvector 5.3.0 版本的全離線安裝包
-│   └── rancher-airgap-v2.8.2.tar.gz    --> Rancher v2.8.2 版本的全離線安裝包
-│   └── rke2-airgap-v1.27.11.tar.gz     --> RKE2 v1.27.11 版本的全離線安裝包
+│   ├── harbor-offline-v2.15.0.tar.gz   --> Harbor v2.15.0 版本的全離線安裝包
+│   ├── k3s-airgap-v1.35.3.tar.gz      --> K3S v1.35.3 版本的全離線安裝包
+│   ├── neuvector-airgap-5.5.0.tar.gz   --> Neuvector 5.5.0 版本的全離線安裝包
+│   └── rancher-airgap-v2.14.0.tar.gz    --> Rancher v2.14.0 版本的全離線安裝包
+│   └── rke2-airgap-v1.35.3.tar.gz     --> RKE2 v1.35.3 版本的全離線安裝包
 ├── harbor
-│   ├── v2.10.0
+│   ├── v2.15.0
 ├── k3s
-│   └── v1.27.11
+│   └── v1.35.3
 ├── neuvector
-│   └── 5.3.0
+│   └── 5.5.0
 ├── rancher
-│   └── v2.8.2
+│   └── v2.14.0
 └── rke2
-    └── v1.27.11
+    └── v1.35.3
 ```
 
 ## Log

--- a/README.md
+++ b/README.md
@@ -156,20 +156,20 @@ Environment variables:
 ## Example:
   ### 一次準備全部五個產品（Harbor、RKE2、Rancher、K3S、Neuvector），並指定 Harbor 特定版本
   ```
-  Harbor_Version=v2.7.0 ./podman-prepare.sh all
+  Harbor_Version=v2.15.0 ./podman-prepare.sh all
   ```
-  ### 只準備 Rancher 的全離線安裝包，並且指定安裝 Rancher v2.7.9 版本
+  ### 只準備 Rancher 的全離線安裝包，並且指定安裝 Rancher v2.13.4 版本
   ```
-  Rancher_Version=v2.7.9 ./podman-prepare.sh rancher
+  Rancher_Version=v2.13.4 ./podman-prepare.sh rancher
   ```
-  ### 準備 Neuvector 的全離線安裝包，並且指定安裝 Neuvector 5.2.0 版本
+  ### 準備 Neuvector 的全離線安裝包，並且指定安裝 Neuvector 5.5.0 版本
   ```
-  Neuvector_Version=5.2.0 ./podman-prepare.sh neuvector
+  Neuvector_Version=5.5.0 ./podman-prepare.sh neuvector
   ```
 
-  ### 同時準備 Rancher、Harbor 和 K3S 的全離線安裝包，分別指定安裝 v2.7.9、v2.7.0 和 v1.25.9 版本，並設定私有 Image Registry 的名稱
+  ### 同時準備 Rancher、Harbor 和 K3S 的全離線安裝包，分別指定安裝 v2.13.4、v2.15.0 和 v1.35.3 版本，並設定私有 Image Registry 的名稱
   ```
-  Rancher_Version=v2.7.9 Harbor_Version=v2.7.0 K3S_Version=v1.25.9 \
+  Rancher_Version=v2.13.4 Harbor_Version=v2.15.0 K3S_Version=v1.35.3 \
   Private_Registry_Name="antony-harbor.example.com" \
   ./podman-prepare.sh rancher harbor k3s
   ```
@@ -177,8 +177,33 @@ Environment variables:
   ### 覆寫 RKE2 來源 URL 與 revision（從 Prime Artifacts 換回 GitHub releases）
   ```
   RKE2_Source_URL=https://github.com/rancher/rke2/releases/download \
-  RKE2_Version=v1.27.11 RKE2_Revision=rke2r1 \
+  RKE2_Version=v1.35.3 RKE2_Revision=rke2r3 \
   ./podman-prepare.sh rke2
+  ```
+
+  ### 準備 K3S，顯式指定版本與 revision 後綴（未來若上游出 k3s2 可直接覆寫）
+  ```
+  K3S_Version=v1.35.3 K3S_Revision=k3s1 \
+  ./podman-prepare.sh k3s
+  ```
+
+  ### 覆寫 K3S 來源 URL（從 Prime Artifacts 換回 GitHub releases）
+  ```
+  K3S_Source_URL=https://github.com/k3s-io/k3s/releases/download \
+  K3S_Version=v1.35.3 K3S_Revision=k3s1 \
+  ./podman-prepare.sh k3s
+  ```
+
+  ### 準備 Rancher，並指定非預設的 cert-manager 版本
+  ```
+  Rancher_Version=v2.13.4 Cert_Manager_Version=v1.20.2 \
+  ./podman-prepare.sh rancher
+  ```
+
+  ### 準備 Rancher，並指定特定 Helm 客戶端版本（會觸發 setup_env 的 Helm↔k8s n-3 相容性 pre-flight 檢查）
+  ```
+  Helm_Version=v3.20.2 Rancher_Version=v2.13.4 \
+  ./podman-prepare.sh rancher
   ```
 
 ## 範例目錄結構

--- a/README.md
+++ b/README.md
@@ -97,7 +97,11 @@ Environment variables:
 
    - Rancher_Version
      定義 Rancher 的版本
-     預設是 'v2.14.0'。
+     預設是 'v2.13.4'。
+
+   - Rancher_Source_URL
+     定義下載 Rancher airgap artifact 的來源 URL
+     預設是 'https://prime.ribs.rancher.io'（Rancher Prime Artifacts）。
 
    - Helm_Version
      定義 Helm 的版本
@@ -156,7 +160,7 @@ Environment variables:
 │   ├── harbor-offline-v2.15.0.tar.gz   --> Harbor v2.15.0 版本的全離線安裝包
 │   ├── k3s-airgap-v1.35.3.tar.gz      --> K3S v1.35.3 版本的全離線安裝包
 │   ├── neuvector-airgap-5.5.0.tar.gz   --> Neuvector 5.5.0 版本的全離線安裝包
-│   └── rancher-airgap-v2.14.0.tar.gz    --> Rancher v2.14.0 版本的全離線安裝包
+│   └── rancher-airgap-v2.13.4.tar.gz    --> Rancher v2.13.4 版本的全離線安裝包
 │   └── rke2-airgap-v1.35.3.tar.gz     --> RKE2 v1.35.3 版本的全離線安裝包
 ├── harbor
 │   ├── v2.15.0
@@ -165,7 +169,7 @@ Environment variables:
 ├── neuvector
 │   └── 5.5.0
 ├── rancher
-│   └── v2.14.0
+│   └── v2.13.4
 └── rke2
     └── v1.35.3
 ```

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ Environment variables:
      定義 RKE2 的版本
      預設是 'v1.27.11'。
 
+   - RKE2_Revision
+     定義 RKE2 的 revision 後綴
+     預設是 'rke2r1'。
+
+   - RKE2_Source_URL
+     定義下載 RKE2 airgap artifact 的來源 URL
+     預設是 'https://prime.ribs.rancher.io'（Rancher Prime Artifacts）。
+
    - Rancher_Version
      定義 Rancher 的版本
      預設是 'v2.8.2'。

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ Environment variables:
      定義 K3S 的版本
      預設是 'v1.35.3'。
 
+   - K3S_Revision
+     定義 K3S 的 revision 後綴
+     預設是 'k3s1'。
+
+   - K3S_Source_URL
+     定義下載 K3S airgap artifact 的來源 URL
+     預設是 'https://prime.ribs.rancher.io'（Rancher Prime Artifacts）。
+
    - Neuvector_Version
      定義 Neuvector 的版本
      預設是 '5.5.0'。

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -5,6 +5,7 @@
 [[ -z "${Command_log_file}" ]] && Command_log_file="/tmp/prepare_message.log"
 [[ -f "${Command_log_file}" ]] && sudo rm "${Command_log_file}"
 exec {BASH_XTRACEFD}>>"${Command_log_file}"
+export PS4='+ [$(date +%H:%M:%S)] ${BASH_SOURCE##*/}:${LINENO}: '
 set -x
 
 ## 預設確保命令執行後的輸出重定向到 /tmp/prepare_output_message.log 檔案中
@@ -192,6 +193,38 @@ run_step() {
   local rc=${PIPESTATUS[0]}
   [[ $rc -ne 0 ]] && exit $rc
   return 0
+}
+
+# 在合併 log 檔寫一個醒目的 section 分隔符，用來標記 prepare_* 函式的進入與結束
+log_section() {
+  local label="$1"
+  local ts; ts=$(date '+%Y-%m-%d %H:%M:%S')
+  {
+    echo ""
+    echo "############################################################"
+    echo "# [$ts] $label"
+    echo "############################################################"
+    echo ""
+  } >> "${Command_Output_log_file}"
+}
+
+# 執行外部命令並把 CMD／輸出／EXIT 一起結構化寫入合併 log 檔（不上螢幕）。
+# 使用：logged_run "<label>" <cmd> <args...>
+# 回傳值為原命令的 exit code，呼叫端既有 `[[ "$?" != "0" ]] && echo ... && exit 1` 仍適用。
+logged_run() {
+  local label="$1"; shift
+  local log="${Command_Output_log_file}"
+  local ts_start; ts_start=$(date '+%Y-%m-%d %H:%M:%S')
+  {
+    echo ""
+    echo "=== [$ts_start] $label ==="
+    echo "CMD: $*"
+  } >> "$log"
+  "$@" >> "$log" 2>&1
+  local rc=$?
+  local ts_end; ts_end=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "=== [$ts_end] EXIT: $rc ===" >> "$log"
+  return $rc
 }
 
 # 建立工作目錄

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -114,7 +114,7 @@ setup_env() {
   for command in wget curl podman
   do
     if ! which $command &> /dev/null; then
-      echo "${Command} command not found!" && exit 1
+      echo "${command} command not found!" && exit 1
     fi
   done
 
@@ -318,7 +318,8 @@ prepare_rancher() {
   printf "\n" >/dev/tty 2>/dev/null || true
 
   # 將 cert-manager 的所有 Container Images 打包成 .tar.gz 壓縮檔
-  podman save -m $(helm template cert-manager-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed -e 's/\"//g' | sed "s|quay.io/jetstack|${Private_Registry_Name}/rancher|g") | gzip --stdout > cert-manager-image-"${Cert_Manager_Version}".tar.gz
+  # 復用前面計算好的 $cert_manager_images，避免重新跑一次 helm template
+  podman save -m $(echo "$cert_manager_images" | sed "s|quay.io/jetstack|${Private_Registry_Name}/rancher|g") | gzip --stdout > cert-manager-image-"${Cert_Manager_Version}".tar.gz
   [[ "$?" != "0" ]] && echo "Podman save Cert-manager ${Cert_Manager_Version} images failed" && exit 1
 
   # 下載 Helm 壓縮檔
@@ -445,7 +446,7 @@ prepare_neuvector() {
   printf "\n" >/dev/tty 2>/dev/null || true
 
   # save images to tar.gz
-  podman save $(cat images-list.txt) | gzip --stdout > neuvector-images-"${Neuvector_Version}".tar.gz
+  podman save -m $(cat images-list.txt) | gzip --stdout > neuvector-images-"${Neuvector_Version}".tar.gz
   [[ "$?" != "0" ]] && echo "Podman save Neuvector images ${Neuvector_Version} failed" && exit 1
 
   cd ../..; tar -czf compressed_files/neuvector-airgap-"${Neuvector_Version}".tar.gz neuvector/"${Neuvector_Version}"

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -244,12 +244,12 @@ prepare_harbor() {
   # 切換工作目錄
   cd ~/work/harbor/"${Harbor_Version}"
 
-  # 下載 Harbor 壓縮檔（-nv：non-verbose，避免 dots 進度條灌 log，保留 "saved to" 摘要）
-  logged_run "harbor: download offline-installer tgz" wget -nv https://github.com/goharbor/harbor/releases/download/"${Harbor_Version}"/harbor-offline-installer-"${Harbor_Version}".tgz
+  # 下載 Harbor 壓縮檔（-nv：non-verbose；-O：顯式覆寫同名檔，避免重跑時產生 *.1）
+  logged_run "harbor: download offline-installer tgz" wget -nv -O harbor-offline-installer-"${Harbor_Version}".tgz https://github.com/goharbor/harbor/releases/download/"${Harbor_Version}"/harbor-offline-installer-"${Harbor_Version}".tgz
   [[ "$?" != "0" ]] && echo "Download harbor-offline-installer-"${Harbor_Version}".tgz failed" && exit 1
 
-  # 下載 Docker Compose 套件
-  logged_run "harbor: download docker-compose" wget -nv https://github.com/docker/compose/releases/download/"${Docker_Compose_Version}"/docker-compose-linux-x86_64
+  # 下載 Docker Compose 套件（-O 同上原因）
+  logged_run "harbor: download docker-compose" wget -nv -O docker-compose-linux-x86_64 https://github.com/docker/compose/releases/download/"${Docker_Compose_Version}"/docker-compose-linux-x86_64
   [[ "$?" != "0" ]] && echo "Download docker-compose-linux-x86_64 "${Docker_Compose_Version}" failed" && exit 1
 
   # 將以上離線安裝 Harbor 所需之套件壓縮成一個檔案
@@ -372,9 +372,11 @@ prepare_rancher() {
   [[ "$?" != "0" ]] && echo "Download helm ${Helm_Version} failed"
 
   # 下載 Rancher Images List 文字檔及蒐集 Image 所需的 Shell Script
+  # -O "${x}"：顯式覆寫同名檔，避免重跑時產生 *.1；舊檔殘留會讓下游 sort -u
+  # 作用在錯的檔（變成前次的 image list），打包出錯到的 tarball
   for x in rancher-images.txt rancher-load-images.sh rancher-save-images.sh
   do
-    logged_run "rancher: download $x" wget -q "${Rancher_Source_URL}"/rancher/"${Rancher_Version}"/"${x}"
+    logged_run "rancher: download $x" wget -q -O "${x}" "${Rancher_Source_URL}"/rancher/"${Rancher_Version}"/"${x}"
     [[ "$?" != "0" ]] && echo "Download ${x} failed" && exit 1
   done
 

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -236,6 +236,7 @@ create_working_directory() {
 # 準備 Harbor 全離線安裝包
 prepare_harbor() {
   setup_env
+  log_section "prepare_harbor START (Harbor_Version=${Harbor_Version})"
 
   # 清除本產品前次產出的離線安裝包，避免與本次新版並存
   rm -f ~/work/compressed_files/harbor-offline-*.tar.gz
@@ -259,11 +260,13 @@ prepare_harbor() {
   else
     echo "Prepare Harbor "${Harbor_Version}" OK."
   fi
+  log_section "prepare_harbor END"
 }
 
 # 準備 RKE2 全離線安裝包
 prepare_rke2() {
   setup_env
+  log_section "prepare_rke2 START (RKE2_Version=${RKE2_Version}, RKE2_Revision=${RKE2_Revision})"
 
   # 清除本產品前次產出的離線安裝包，避免與本次新版並存
   rm -f ~/work/compressed_files/rke2-airgap-*.tar.gz
@@ -294,12 +297,14 @@ prepare_rke2() {
   else
     echo "Prepare RKE2 "${RKE2_Version}" OK."
   fi
+  log_section "prepare_rke2 END"
 }
 
 # 準備 Rancher Prime 全離線安裝包
 prepare_rancher() {
 
   setup_env
+  log_section "prepare_rancher START (Rancher_Version=${Rancher_Version})"
 
   # 清除本產品前次產出的離線安裝包，避免與本次新版並存
   rm -f ~/work/compressed_files/rancher-airgap-*.tar.gz
@@ -416,10 +421,12 @@ prepare_rancher() {
   else
     echo "Prepare Rancher "${Rancher_Version}" OK."
   fi
+  log_section "prepare_rancher END"
 }
 
 prepare_k3s() {
   setup_env
+  log_section "prepare_k3s START (K3S_Version=${K3S_Version})"
 
   # 清除本產品前次產出的離線安裝包，避免與本次新版並存
   rm -f ~/work/compressed_files/k3s-airgap-*.tar.gz
@@ -444,10 +451,12 @@ prepare_k3s() {
   else
     echo "Prepare K3S "${K3S_Version}" OK."
   fi
+  log_section "prepare_k3s END"
 }
 
 prepare_neuvector() {
   setup_env
+  log_section "prepare_neuvector START (Neuvector_Version=${Neuvector_Version})"
 
   # 清除本產品前次產出的離線安裝包，避免與本次新版並存
   rm -f ~/work/compressed_files/neuvector-airgap-*.tar.gz
@@ -501,6 +510,7 @@ prepare_neuvector() {
   else
     echo "Prepare Neuvector ${Neuvector_Version} OK."
   fi
+  log_section "prepare_neuvector END"
 }
 
 while [[ "$#" -gt "0" ]]

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -340,6 +340,10 @@ prepare_rancher() {
   logged_run "rancher: download cert-manager CRD" curl -sSL -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.crds.yaml
   [[ "$?" != "0" ]] && echo "Download Cert_Manager CRD failed" && exit 1
 
+  # 下載 cert-manager 官方 combined install manifest（kubectl apply 路徑用；版本跟著 ${Cert_Manager_Version}）
+  logged_run "rancher: download cert-manager manifest" curl -sSL -o cert-manager.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.yaml
+  [[ "$?" != "0" ]] && echo "Download Cert_Manager manifest failed" && exit 1
+
   # 處理 cert-manager 的 Container Images
   # 先計算 cert-manager 所需 image 總量，作為進度列的分母
   cert_manager_images=$(helm template cert-manager-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed -e 's/\"//g')

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -323,8 +323,8 @@ prepare_rancher() {
   [[ "$?" != "0" ]] && echo "helm repo update (rancher-prime) failed" && exit 1
 
   # 下載 Rancher chart
-  logged_run "rancher: helm fetch rancher chart" helm fetch rancher-prime/rancher --version="${Rancher_Version}"
-  [[ "$?" != "0" ]] && echo "helm fetch rancher failed" && exit 1
+  logged_run "rancher: helm pull rancher chart" helm pull rancher-prime/rancher --version="${Rancher_Version}"
+  [[ "$?" != "0" ]] && echo "helm pull rancher failed" && exit 1
 
   # 新增和刷新 cert-manager repo
   logged_run "rancher: helm repo add jetstack" helm repo add jetstack https://charts.jetstack.io
@@ -333,8 +333,8 @@ prepare_rancher() {
   [[ "$?" != "0" ]] && echo "helm repo update (jetstack) failed" && exit 1
 
   # 下載 cert-manager chart
-  logged_run "rancher: helm fetch cert-manager chart" helm fetch jetstack/cert-manager --version "${Cert_Manager_Version}"
-  [[ "$?" != "0" ]] && echo "helm fetch Cert_Manager failed" && exit 1
+  logged_run "rancher: helm pull cert-manager chart" helm pull jetstack/cert-manager --version "${Cert_Manager_Version}"
+  [[ "$?" != "0" ]] && echo "helm pull Cert_Manager failed" && exit 1
 
   # 下載 cert-manager 要求的 CRD（-sSL：silent + show-error + follow-redirect）
   logged_run "rancher: download cert-manager CRD" curl -sSL -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.crds.yaml

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -184,6 +184,16 @@ print_progress() {
   printf "\r\033[K[%s %d/%d] %s" "$1" "$2" "$3" "$4" >/dev/tty 2>/dev/null || true
 }
 
+# 呼叫 function/command 並把 stdout/stderr 導入 log 檔；若呼叫者非零結束，
+# 整支腳本立即以相同 exit code 結束（用 PIPESTATUS[0] 取 pipeline 第一段狀態，
+# 避免 `prepare_* | tee` 把 function 包進 subshell 後 `exit 1` 只結束 subshell 的問題）
+run_step() {
+  "$@" 2>&1 | tee -a "${Command_Output_log_file}"
+  local rc=${PIPESTATUS[0]}
+  [[ $rc -ne 0 ]] && exit $rc
+  return 0
+}
+
 # 建立工作目錄
 create_working_directory() {
   setup_env
@@ -451,35 +461,37 @@ do
   option="$1"
   case $option in
     all)
-      create_working_directory 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_harbor 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_rke2 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_rancher 2>&1 | tee -a "${Command_Output_log_file}"
+      run_step create_working_directory
+      run_step prepare_harbor
+      run_step prepare_rke2
+      run_step prepare_rancher
+      run_step prepare_k3s
+      run_step prepare_neuvector
       exit 0
     ;;
     harbor)
-      create_working_directory 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_harbor 2>&1 | tee -a "${Command_Output_log_file}"
+      run_step create_working_directory
+      run_step prepare_harbor
       shift
     ;;
     rke2)
-      create_working_directory 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_rke2 2>&1 | tee -a "${Command_Output_log_file}"
+      run_step create_working_directory
+      run_step prepare_rke2
       shift
     ;;
     rancher)
-      create_working_directory 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_rancher 2>&1 | tee -a "${Command_Output_log_file}"
+      run_step create_working_directory
+      run_step prepare_rancher
       shift
     ;;
     k3s)
-      create_working_directory 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_k3s 2>&1 | tee -a "${Command_Output_log_file}"
+      run_step create_working_directory
+      run_step prepare_k3s
       shift
     ;;
     neuvector)
-      create_working_directory 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_neuvector 2>&1 | tee -a "${Command_Output_log_file}"
+      run_step create_working_directory
+      run_step prepare_neuvector
       shift
     ;;
     *)

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -178,6 +178,12 @@ setup_env() {
   if [[ -z "${Private_Registry_Name}" ]]; then
     Private_Registry_Name="harbor.example.com"
   fi
+
+  # Helm 與 k8s n-3 相容性 pre-flight check；fail 時 exit 以避免打包出無法用的 airgap 包
+  if ! helm_version_skew_check; then
+    echo "[helm version skew] 版本不相容，停止執行。詳見 https://helm.sh/docs/topics/version_skew/" >&2
+    exit 1
+  fi
 }
 
 # 印進度列到終端（同一行覆寫），非 TTY 時靜默
@@ -224,6 +230,52 @@ logged_run() {
   local rc=$?
   local ts_end; ts_end=$(date '+%Y-%m-%d %H:%M:%S')
   echo "=== [$ts_end] EXIT: $rc ===" >> "$log"
+  return $rc
+}
+
+# 檢查 ${Helm_Version} compiled-against 的 k8s minor 與 ${RKE2_Version}／${K3S_Version}
+# 是否落在 Helm n-3 support window 內（https://helm.sh/docs/topics/version_skew/）。
+# 規律（v3.x 系列）：Helm 3.N 對應 k8s.io/client-go v0.(N+15) → k8s 1.(N+15)。
+# 例：v3.20 → k8s 1.35，支援 1.32 – 1.35；v3.14 → k8s 1.29，支援 1.26 – 1.29。
+# 非 v3.x（例：v4.x）目前不自動判斷，僅 echo 提示請使用者自行對照文件。
+helm_version_skew_check() {
+  local helm_ver="${Helm_Version#v}"
+  local helm_major="${helm_ver%%.*}"
+  local helm_minor_rest="${helm_ver#*.}"
+  local helm_minor="${helm_minor_rest%%.*}"
+
+  if [[ "$helm_major" != "3" ]]; then
+    echo "[helm version skew] Helm_Version=${Helm_Version} 非 v3.x，跳過自動相容性檢查；請自行對照 https://helm.sh/docs/topics/version_skew/" >&2
+    return 0
+  fi
+
+  local helm_k8s_target=$((helm_minor + 15))       # e.g. Helm 3.20 → k8s 1.35
+  local helm_k8s_min=$((helm_k8s_target - 3))      # n-3 下界，e.g. 1.32
+
+  local target_names=("RKE2" "K3S")
+  local target_vars=("${RKE2_Version}" "${K3S_Version}")
+  local rc=0
+  local i
+  for i in "${!target_vars[@]}"; do
+    local tv="${target_vars[$i]#v}"
+    local tn="${target_names[$i]}"
+    local t_major="${tv%%.*}"
+    local t_minor_rest="${tv#*.}"
+    local t_minor="${t_minor_rest%%.*}"
+
+    if [[ "$t_major" != "1" ]]; then
+      echo "[helm version skew] ${tn}_Version=${target_vars[$i]} 非 v1.x，跳過" >&2
+      continue
+    fi
+
+    if (( t_minor > helm_k8s_target )); then
+      echo "[helm version skew] ${tn}_Version=${target_vars[$i]}（k8s 1.${t_minor}）比 Helm_Version=${Helm_Version} compiled-against 的 k8s 1.${helm_k8s_target} 還新；超出 Helm 支援範圍 → 升 Helm_Version" >&2
+      rc=1
+    elif (( t_minor < helm_k8s_min )); then
+      echo "[helm version skew] ${tn}_Version=${target_vars[$i]}（k8s 1.${t_minor}）早於 Helm_Version=${Helm_Version} 的 n-3 下界 1.${helm_k8s_min} → 降 Helm_Version 或升 ${tn}_Version" >&2
+      rc=1
+    fi
+  done
   return $rc
 }
 

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -189,6 +189,9 @@ create_working_directory() {
 prepare_harbor() {
   setup_env
 
+  # 清除本產品前次產出的離線安裝包，避免與本次新版並存
+  rm -f ~/work/compressed_files/harbor-offline-*.tar.gz
+
   # 切換工作目錄
   cd ~/work/harbor/"${Harbor_Version}"
 
@@ -212,6 +215,10 @@ prepare_harbor() {
 # 準備 RKE2 全離線安裝包
 prepare_rke2() {
   setup_env
+
+  # 清除本產品前次產出的離線安裝包，避免與本次新版並存
+  rm -f ~/work/compressed_files/rke2-airgap-*.tar.gz
+
   # 切換工作目錄
   cd ~/work/rke2/"${RKE2_Version}"
 
@@ -242,6 +249,10 @@ prepare_rke2() {
 prepare_rancher() {
 
   setup_env
+
+  # 清除本產品前次產出的離線安裝包，避免與本次新版並存
+  rm -f ~/work/compressed_files/rancher-airgap-*.tar.gz
+
   # 切換工作目錄
   cd ~/work/rancher/"${Rancher_Version}"
 
@@ -338,6 +349,9 @@ prepare_rancher() {
 prepare_k3s() {
   setup_env
 
+  # 清除本產品前次產出的離線安裝包，避免與本次新版並存
+  rm -f ~/work/compressed_files/k3s-airgap-*.tar.gz
+
   # 切換工作目錄
   cd ~/work/k3s/"${K3S_Version}"
 
@@ -360,6 +374,9 @@ prepare_k3s() {
 
 prepare_neuvector() {
   setup_env
+
+  # 清除本產品前次產出的離線安裝包，避免與本次新版並存
+  rm -f ~/work/compressed_files/neuvector-airgap-*.tar.gz
 
   # 切換工作目錄
   cd ~/work/neuvector/"${Neuvector_Version}"

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -39,6 +39,14 @@ Environment variables:
      定義 RKE2 的版本
      預設是 'v1.27.11'。
 
+   - RKE2_Revision
+     定義 RKE2 的 revision 後綴
+     預設是 'rke2r1'。
+
+   - RKE2_Source_URL
+     定義下載 RKE2 airgap artifact 的來源 URL
+     預設是 'https://prime.ribs.rancher.io'（Rancher Prime Artifacts）。
+
    - Rancher_Version
      定義 Rancher 的版本
      預設是 'v2.8.2'。
@@ -121,6 +129,16 @@ setup_env() {
     RKE2_Version="v1.27.11"
   fi
 
+  # make sure the revision of the RKE2 is defined
+  if [[ -z "${RKE2_Revision}" ]]; then
+    RKE2_Revision="rke2r1"
+  fi
+
+  # make sure the URL of the RKE2 source is defined
+  if [[ -z "${RKE2_Source_URL}" ]]; then
+    RKE2_Source_URL="https://prime.ribs.rancher.io"
+  fi
+
   # make sure the version of the Rancher is defined
   if [[ -z "${Rancher_Version}" ]]; then
     Rancher_Version="v2.8.2"
@@ -189,13 +207,13 @@ prepare_rke2() {
   cd ~/work/rke2/"${RKE2_Version}"
 
   # 下載離線安裝 RKE2 所需 Image 之壓縮檔
-  curl -s -OL https://github.com/rancher/rke2/releases/download/"${RKE2_Version}"%2Brke2r1/rke2-images.linux-amd64.tar.zst &>> "${Command_Output_log_file}"
+  curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/rke2-images.linux-amd64.tar.zst &>> "${Command_Output_log_file}"
   [[ "$?" != "0" ]] && echo "Download rke2-images.linux-amd64.tar.zst "${RKE2_Version}" failed" && exit 1
 
-  curl -s -OL https://github.com/rancher/rke2/releases/download/"${RKE2_Version}"%2Brke2r1/rke2.linux-amd64.tar.gz &>> "${Command_Output_log_file}"
+  curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/rke2.linux-amd64.tar.gz &>> "${Command_Output_log_file}"
   [[ "$?" != "0" ]] && echo "Download rke2.linux-amd64.tar.gz "${RKE2_Version}" failed" && exit 1
 
-  curl -s -OL https://github.com/rancher/rke2/releases/download/"${RKE2_Version}"%2Brke2r1/sha256sum-amd64.txt &>> "${Command_Output_log_file}"
+  curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/sha256sum-amd64.txt &>> "${Command_Output_log_file}"
   [[ "$?" != "0" ]] && echo "Download sha256sum-amd64.txt "${RKE2_Version}" failed" && exit 1
 
   # 下載官網提供的離線安裝 RKE2 所需之安裝腳本，並賦予它執行權限

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -29,19 +29,19 @@ Environment variables:
 
    - Harbor_Version
      定義 Harbor 的版本
-     預設是 'v2.10.0'。
+     預設是 'v2.15.0'。
 
    - Docker_Compose_Version
      定義 docker-compose 的版本
-     預設是 'v2.24.7'。
+     預設是 'v2.40.3'。
 
    - RKE2_Version
      定義 RKE2 的版本
-     預設是 'v1.27.11'。
+     預設是 'v1.35.3'。
 
    - RKE2_Revision
      定義 RKE2 的 revision 後綴
-     預設是 'rke2r1'。
+     預設是 'rke2r3'。
 
    - RKE2_Source_URL
      定義下載 RKE2 airgap artifact 的來源 URL
@@ -49,11 +49,11 @@ Environment variables:
 
    - Rancher_Version
      定義 Rancher 的版本
-     預設是 'v2.8.2'。
+     預設是 'v2.14.0'。
 
    - Helm_Version
      定義 Helm 的版本
-     預設是 'v3.14.2'。
+     預設是 'v3.20.2'。
 
    - Cert_Manager_Version
      定義 Cert-manager 的版本
@@ -61,11 +61,11 @@ Environment variables:
 
    - K3S_Version
      定義 K3S 的版本
-     預設是 'v1.27.11'。
+     預設是 'v1.35.3'。
 
    - Neuvector_Version
      定義 Neuvector 的版本
-     預設是 '5.3.0'。
+     預設是 '5.5.0'。
 
    - Private_Registry_Name
      定義企業內部私有 Image Registry 的名稱
@@ -116,22 +116,22 @@ setup_env() {
 
   # make sure the version of the Harbor is defined
   if [[ -z "${Harbor_Version}" ]]; then
-    Harbor_Version="v2.10.0"
+    Harbor_Version="v2.15.0"
   fi
 
   # make sure the version of the Docker-compose is defined
   if [[ -z "${Docker_Compose_Version}" ]]; then
-    Docker_Compose_Version="v2.24.7"
+    Docker_Compose_Version="v2.40.3"
   fi
 
   # make sure the version of the RKE2 is defined
   if [[ -z "${RKE2_Version}" ]]; then
-    RKE2_Version="v1.27.11"
+    RKE2_Version="v1.35.3"
   fi
 
   # make sure the revision of the RKE2 is defined
   if [[ -z "${RKE2_Revision}" ]]; then
-    RKE2_Revision="rke2r1"
+    RKE2_Revision="rke2r3"
   fi
 
   # make sure the URL of the RKE2 source is defined
@@ -141,12 +141,12 @@ setup_env() {
 
   # make sure the version of the Rancher is defined
   if [[ -z "${Rancher_Version}" ]]; then
-    Rancher_Version="v2.8.2"
+    Rancher_Version="v2.14.0"
   fi
 
   # make sure the version of the Helm is defined
   if [[ -z "${Helm_Version}" ]]; then
-    Helm_Version="v3.14.2"
+    Helm_Version="v3.20.2"
   fi
 
   # make sure the version of the Cert-Manager is defined
@@ -156,12 +156,12 @@ setup_env() {
 
   # make sure the version of the K3S is defined
   if [[ -z "${K3S_Version}" ]]; then
-    K3S_Version="v1.27.11"
+    K3S_Version="v1.35.3"
   fi
 
   # make sure the version of the Neuvector is defined
   if [[ -z "${Neuvector_Version}" ]]; then
-    Neuvector_Version="5.3.0"
+    Neuvector_Version="5.5.0"
   fi
 
   # make sure the name of the Private Images Registry is defined

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -244,12 +244,12 @@ prepare_harbor() {
   # 切換工作目錄
   cd ~/work/harbor/"${Harbor_Version}"
 
-  # 下載 Harbor 壓縮檔
-  logged_run "harbor: download offline-installer tgz" wget https://github.com/goharbor/harbor/releases/download/"${Harbor_Version}"/harbor-offline-installer-"${Harbor_Version}".tgz
+  # 下載 Harbor 壓縮檔（-nv：non-verbose，避免 dots 進度條灌 log，保留 "saved to" 摘要）
+  logged_run "harbor: download offline-installer tgz" wget -nv https://github.com/goharbor/harbor/releases/download/"${Harbor_Version}"/harbor-offline-installer-"${Harbor_Version}".tgz
   [[ "$?" != "0" ]] && echo "Download harbor-offline-installer-"${Harbor_Version}".tgz failed" && exit 1
 
   # 下載 Docker Compose 套件
-  logged_run "harbor: download docker-compose" wget https://github.com/docker/compose/releases/download/"${Docker_Compose_Version}"/docker-compose-linux-x86_64
+  logged_run "harbor: download docker-compose" wget -nv https://github.com/docker/compose/releases/download/"${Docker_Compose_Version}"/docker-compose-linux-x86_64
   [[ "$?" != "0" ]] && echo "Download docker-compose-linux-x86_64 "${Docker_Compose_Version}" failed" && exit 1
 
   # 將以上離線安裝 Harbor 所需之套件壓縮成一個檔案
@@ -336,8 +336,8 @@ prepare_rancher() {
   logged_run "rancher: helm fetch cert-manager chart" helm fetch jetstack/cert-manager --version "${Cert_Manager_Version}"
   [[ "$?" != "0" ]] && echo "helm fetch Cert_Manager failed" && exit 1
 
-  # 下載 cert-manager 要求的 CRD
-  logged_run "rancher: download cert-manager CRD" curl -L -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.crds.yaml
+  # 下載 cert-manager 要求的 CRD（-sSL：silent + show-error + follow-redirect）
+  logged_run "rancher: download cert-manager CRD" curl -sSL -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.crds.yaml
   [[ "$?" != "0" ]] && echo "Download Cert_Manager CRD failed" && exit 1
 
   # 處理 cert-manager 的 Container Images
@@ -434,10 +434,11 @@ prepare_k3s() {
   # 切換工作目錄
   cd ~/work/k3s/"${K3S_Version}"
 
-  logged_run "k3s: download k3s-airgap-images-amd64.tar" curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s-airgap-images-amd64.tar
+  # -sSL：silent + show-error + follow-redirect，去掉 -# 的 hash progress bar
+  logged_run "k3s: download k3s-airgap-images-amd64.tar" curl -sSL -O https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s-airgap-images-amd64.tar
   [[ "$?" != "0" ]] && echo "Download k3s-airgap-images-amd64.tar ${K3S_Version} failed" && exit 1
 
-  logged_run "k3s: download k3s binary" curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s
+  logged_run "k3s: download k3s binary" curl -sSL -O https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s
   [[ "$?" != "0" ]] && echo "Download k3s Binary File ${K3S_Version} failed" && exit 1
 
   logged_run "k3s: download install.sh" curl -sfL https://get.k3s.io/ --output install.sh

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -179,6 +179,11 @@ setup_env() {
   fi
 }
 
+# 印進度列到終端（同一行覆寫），非 TTY 時靜默
+print_progress() {
+  printf "\r\033[K[%s %d/%d] %s" "$1" "$2" "$3" "$4" >/dev/tty 2>/dev/null || true
+}
+
 # 建立工作目錄
 create_working_directory() {
   setup_env
@@ -283,16 +288,24 @@ prepare_rancher() {
   [[ "$?" != "0" ]] && echo "Download Cert_Manager CRD failed" && exit 1
 
   # 處理 cert-manager 的 Container Images
-  for i in $(helm template cert-manager-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed -e 's/\"//g')
+  # 先計算 cert-manager 所需 image 總量，作為進度列的分母
+  cert_manager_images=$(helm template cert-manager-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed -e 's/\"//g')
+  cert_manager_total=$(echo "$cert_manager_images" | wc -l)
+  idx=0
+  for image in $cert_manager_images
   do
+    idx=$((idx + 1))
+    print_progress "cert-manager" "$idx" "$cert_manager_total" "$image"
+
     # 下載 cert-manager 的 Container Images
-    podman pull "$i" &>> "${Command_Output_log_file}"
-    [[ "$?" != "0" ]] && echo "Pull quay.io/jetstack/$i Container images failed" && exit 1
+    podman pull "$image" &>> "${Command_Output_log_file}"
+    [[ "$?" != "0" ]] && { printf "\n" >/dev/tty 2>/dev/null; echo "Pull quay.io/jetstack/$image Container images failed"; exit 1; }
 
     # 修改 cert-manager 的所有 Container Images Tag
-    podman tag "${i}" "${Private_Registry_Name}"/rancher/"${i##*/}" &>> "${Command_Output_log_file}"
-    [[ "$?" != "0" ]] && echo "tag ${Private_Registry_Name}/rancher/${i##*/} Container images failed" && exit 1
+    podman tag "${image}" "${Private_Registry_Name}"/rancher/"${image##*/}" &>> "${Command_Output_log_file}"
+    [[ "$?" != "0" ]] && { printf "\n" >/dev/tty 2>/dev/null; echo "tag ${Private_Registry_Name}/rancher/${image##*/} Container images failed"; exit 1; }
   done
+  printf "\n" >/dev/tty 2>/dev/null || true
 
   # 將 cert-manager 的所有 Container Images 打包成 .tar.gz 壓縮檔
   podman save -m $(helm template cert-manager-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed -e 's/\"//g' | sed "s|quay.io/jetstack|${Private_Registry_Name}/rancher|g") | gzip --stdout > cert-manager-image-"${Cert_Manager_Version}".tar.gz
@@ -314,12 +327,18 @@ prepare_rancher() {
 
   [[ "$?" == "0" ]] && echo "Start pulling and saving rancher ${Rancher_Version} images in the background..."
   # 下載離線安裝 Rancher 所需的所有 Container Images 並打包成 rancher-images.tar.gz
+  rancher_total=$(wc -l < rancher-images.txt)
+  idx=0
   while read image
   do
+    idx=$((idx + 1))
+    print_progress "rancher" "$idx" "$rancher_total" "$image"
     if ! podman pull registry.rancher.com/"${image}" &>> "${Command_Output_log_file}"; then
+      printf "\n" >/dev/tty 2>/dev/null || true
       echo pull "$image" failed && exit 1
     fi
   done <<< $(cat rancher-images.txt)
+  printf "\n" >/dev/tty 2>/dev/null || true
 
   rancher_all_image=$(cat rancher-images.txt | sed 's|^|registry.rancher.com/|' | tr '\n' ' ')
   for n in $rancher_all_image
@@ -404,11 +423,16 @@ prepare_neuvector() {
   helm template core-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed -e 's/\"//g' > images-list.txt 2>> "${Command_Output_log_file}"
 
   # get images
-  for i in $(cat images-list.txt)
+  neuvector_total=$(wc -l < images-list.txt)
+  idx=0
+  for image in $(cat images-list.txt)
   do
-    podman pull $i &>> "${Command_Output_log_file}"
-    [[ "$?" != "0" ]] && echo "Pull $i failed" && exit 1
+    idx=$((idx + 1))
+    print_progress "neuvector" "$idx" "$neuvector_total" "$image"
+    podman pull "$image" &>> "${Command_Output_log_file}"
+    [[ "$?" != "0" ]] && { printf "\n" >/dev/tty 2>/dev/null; echo "Pull $image failed"; exit 1; }
   done
+  printf "\n" >/dev/tty 2>/dev/null || true
 
   # save images to tar.gz
   podman save $(cat images-list.txt) | gzip --stdout > neuvector-images-"${Neuvector_Version}".tar.gz

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -244,15 +244,16 @@ prepare_harbor() {
   cd ~/work/harbor/"${Harbor_Version}"
 
   # 下載 Harbor 壓縮檔
-  wget https://github.com/goharbor/harbor/releases/download/"${Harbor_Version}"/harbor-offline-installer-"${Harbor_Version}".tgz &>> "${Command_Output_log_file}"
+  logged_run "harbor: download offline-installer tgz" wget https://github.com/goharbor/harbor/releases/download/"${Harbor_Version}"/harbor-offline-installer-"${Harbor_Version}".tgz
   [[ "$?" != "0" ]] && echo "Download harbor-offline-installer-"${Harbor_Version}".tgz failed" && exit 1
 
   # 下載 Docker Compose 套件
-  wget https://github.com/docker/compose/releases/download/"${Docker_Compose_Version}"/docker-compose-linux-x86_64 &>> "${Command_Output_log_file}"
+  logged_run "harbor: download docker-compose" wget https://github.com/docker/compose/releases/download/"${Docker_Compose_Version}"/docker-compose-linux-x86_64
   [[ "$?" != "0" ]] && echo "Download docker-compose-linux-x86_64 "${Docker_Compose_Version}" failed" && exit 1
 
   # 將以上離線安裝 Harbor 所需之套件壓縮成一個檔案
-  cd ../..; tar -czvf compressed_files/harbor-offline-"${Harbor_Version}".tar.gz harbor/"${Harbor_Version}" &>> "${Command_Output_log_file}"
+  cd ../..
+  logged_run "harbor: tar airgap bundle" tar -czvf compressed_files/harbor-offline-"${Harbor_Version}".tar.gz harbor/"${Harbor_Version}"
   if [[ "$?" != "0" ]]; then
     echo "Preparing harbor full Air Gap installer failed" && exit 1
   else
@@ -271,21 +272,23 @@ prepare_rke2() {
   cd ~/work/rke2/"${RKE2_Version}"
 
   # 下載離線安裝 RKE2 所需 Image 之壓縮檔
-  curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/rke2-images.linux-amd64.tar.zst &>> "${Command_Output_log_file}"
+  logged_run "rke2: download rke2-images.linux-amd64.tar.zst" curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/rke2-images.linux-amd64.tar.zst
   [[ "$?" != "0" ]] && echo "Download rke2-images.linux-amd64.tar.zst "${RKE2_Version}" failed" && exit 1
 
-  curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/rke2.linux-amd64.tar.gz &>> "${Command_Output_log_file}"
+  logged_run "rke2: download rke2.linux-amd64.tar.gz" curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/rke2.linux-amd64.tar.gz
   [[ "$?" != "0" ]] && echo "Download rke2.linux-amd64.tar.gz "${RKE2_Version}" failed" && exit 1
 
-  curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/sha256sum-amd64.txt &>> "${Command_Output_log_file}"
+  logged_run "rke2: download sha256sum-amd64.txt" curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/sha256sum-amd64.txt
   [[ "$?" != "0" ]] && echo "Download sha256sum-amd64.txt "${RKE2_Version}" failed" && exit 1
 
   # 下載官網提供的離線安裝 RKE2 所需之安裝腳本，並賦予它執行權限
-  curl -sfL https://get.rke2.io --output install.sh && chmod +x install.sh &>> "${Command_Output_log_file}"
+  logged_run "rke2: download install.sh" curl -sfL https://get.rke2.io --output install.sh
   [[ "$?" != "0" ]] && echo "Download rke2 install.sh failed" && exit 1
+  logged_run "rke2: chmod install.sh" chmod +x install.sh
 
   # 將以上離線安裝 RKE2 所需之檔案，壓縮成一個檔案
-  cd ../..; tar -czvf compressed_files/rke2-airgap-"${RKE2_Version}".tar.gz rke2/"${RKE2_Version}" &>> "${Command_Output_log_file}"
+  cd ../..
+  logged_run "rke2: tar airgap bundle" tar -czvf compressed_files/rke2-airgap-"${RKE2_Version}".tar.gz rke2/"${RKE2_Version}"
   if [[ "$?" != "0" ]]; then
     echo "Preparing RKE2 Air Gap installer failed" && exit 1
   else
@@ -305,29 +308,31 @@ prepare_rancher() {
   cd ~/work/rancher/"${Rancher_Version}"
 
   # 安裝 helm
-  curl -s https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash &>> "${Command_Output_log_file}"
+  logged_run "rancher: install helm" bash -c 'curl -s https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash'
   [[ "$?" != "0" ]] && echo "Install helm failed" && exit 1
 
   # 新增並刷新 Rancher Prime 的 Helm Chart Repository
-  helm repo add rancher-prime https://charts.rancher.com/server-charts/prime &>> "${Command_Output_log_file}" && \
-  helm repo update &>> "${Command_Output_log_file}"
-  [[ "$?" != "0" ]] && echo "helm repo add or update rancher-prime failed" && exit 1
+  logged_run "rancher: helm repo add rancher-prime" helm repo add rancher-prime https://charts.rancher.com/server-charts/prime
+  [[ "$?" != "0" ]] && echo "helm repo add rancher-prime failed" && exit 1
+  logged_run "rancher: helm repo update (rancher-prime)" helm repo update
+  [[ "$?" != "0" ]] && echo "helm repo update (rancher-prime) failed" && exit 1
 
   # 下載 Rancher chart
-  helm fetch rancher-prime/rancher --version="${Rancher_Version}" &>> "${Command_Output_log_file}"
+  logged_run "rancher: helm fetch rancher chart" helm fetch rancher-prime/rancher --version="${Rancher_Version}"
   [[ "$?" != "0" ]] && echo "helm fetch rancher failed" && exit 1
 
   # 新增和刷新 cert-manager repo
-  helm repo add jetstack https://charts.jetstack.io &>> "${Command_Output_log_file}" && \
-  helm repo update &>> "${Command_Output_log_file}"
-  [[ "$?" != "0" ]] && echo "helm repo add or update cert-manager failed" && exit 1
+  logged_run "rancher: helm repo add jetstack" helm repo add jetstack https://charts.jetstack.io
+  [[ "$?" != "0" ]] && echo "helm repo add jetstack failed" && exit 1
+  logged_run "rancher: helm repo update (jetstack)" helm repo update
+  [[ "$?" != "0" ]] && echo "helm repo update (jetstack) failed" && exit 1
 
   # 下載 cert-manager chart
-  helm fetch jetstack/cert-manager --version "${Cert_Manager_Version}" &>> "${Command_Output_log_file}"
+  logged_run "rancher: helm fetch cert-manager chart" helm fetch jetstack/cert-manager --version "${Cert_Manager_Version}"
   [[ "$?" != "0" ]] && echo "helm fetch Cert_Manager failed" && exit 1
 
   # 下載 cert-manager 要求的 CRD
-  curl -L -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.crds.yaml &>> "${Command_Output_log_file}"
+  logged_run "rancher: download cert-manager CRD" curl -L -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.crds.yaml
   [[ "$?" != "0" ]] && echo "Download Cert_Manager CRD failed" && exit 1
 
   # 處理 cert-manager 的 Container Images
@@ -341,33 +346,35 @@ prepare_rancher() {
     print_progress "cert-manager" "$idx" "$cert_manager_total" "$image"
 
     # 下載 cert-manager 的 Container Images
-    podman pull "$image" &>> "${Command_Output_log_file}"
+    logged_run "cert-manager [$idx/$cert_manager_total] pull $image" podman pull "$image"
     [[ "$?" != "0" ]] && { printf "\n" >/dev/tty 2>/dev/null; echo "Pull quay.io/jetstack/$image Container images failed"; exit 1; }
 
     # 修改 cert-manager 的所有 Container Images Tag
-    podman tag "${image}" "${Private_Registry_Name}"/rancher/"${image##*/}" &>> "${Command_Output_log_file}"
+    logged_run "cert-manager [$idx/$cert_manager_total] tag $image" podman tag "${image}" "${Private_Registry_Name}"/rancher/"${image##*/}"
     [[ "$?" != "0" ]] && { printf "\n" >/dev/tty 2>/dev/null; echo "tag ${Private_Registry_Name}/rancher/${image##*/} Container images failed"; exit 1; }
   done
   printf "\n" >/dev/tty 2>/dev/null || true
 
   # 將 cert-manager 的所有 Container Images 打包成 .tar.gz 壓縮檔
   # 復用前面計算好的 $cert_manager_images，避免重新跑一次 helm template
-  podman save -m $(echo "$cert_manager_images" | sed "s|quay.io/jetstack|${Private_Registry_Name}/rancher|g") | gzip --stdout > cert-manager-image-"${Cert_Manager_Version}".tar.gz
+  # pipe 用 bash -c 包，set -o pipefail 讓 save 或 gzip 任一段失敗都能正確回傳
+  cert_manager_renamed_images=$(echo "$cert_manager_images" | sed "s|quay.io/jetstack|${Private_Registry_Name}/rancher|g" | tr '\n' ' ')
+  logged_run "cert-manager: save images tar.gz" bash -c "set -o pipefail; podman save -m ${cert_manager_renamed_images} | gzip --stdout > cert-manager-image-${Cert_Manager_Version}.tar.gz"
   [[ "$?" != "0" ]] && echo "Podman save Cert-manager ${Cert_Manager_Version} images failed" && exit 1
 
   # 下載 Helm 壓縮檔
-  wget -q https://get.helm.sh/helm-"${Helm_Version}"-linux-amd64.tar.gz -O helm-"${Helm_Version}"-linux-amd64.tar.gz &>> "${Command_Output_log_file}"
+  logged_run "rancher: download helm ${Helm_Version} tarball" wget -q https://get.helm.sh/helm-"${Helm_Version}"-linux-amd64.tar.gz -O helm-"${Helm_Version}"-linux-amd64.tar.gz
   [[ "$?" != "0" ]] && echo "Download helm ${Helm_Version} failed"
 
   # 下載 Rancher Images List 文字檔及蒐集 Image 所需的 Shell Script
   for x in rancher-images.txt rancher-load-images.sh rancher-save-images.sh
   do
-    wget -q "${Rancher_Source_URL}"/rancher/"${Rancher_Version}"/"${x}" &>> "${Command_Output_log_file}"
+    logged_run "rancher: download $x" wget -q "${Rancher_Source_URL}"/rancher/"${Rancher_Version}"/"${x}"
     [[ "$?" != "0" ]] && echo "Download ${x} failed" && exit 1
   done
 
   # 對 Image List 進行排序和唯一化，以消除來源之間的任何重疊
-  sort -u rancher-images.txt -o rancher-images.txt &>> "${Command_Output_log_file}"
+  logged_run "rancher: sort-uniq rancher-images.txt" sort -u rancher-images.txt -o rancher-images.txt
 
   [[ "$?" == "0" ]] && echo "Start pulling and saving rancher ${Rancher_Version} images in the background..."
   # 下載離線安裝 Rancher 所需的所有 Container Images 並打包成 rancher-images.tar.gz
@@ -377,7 +384,7 @@ prepare_rancher() {
   do
     idx=$((idx + 1))
     print_progress "rancher" "$idx" "$rancher_total" "$image"
-    if ! podman pull registry.rancher.com/"${image}" &>> "${Command_Output_log_file}"; then
+    if ! logged_run "rancher [$idx/$rancher_total] pull $image" podman pull registry.rancher.com/"${image}"; then
       printf "\n" >/dev/tty 2>/dev/null || true
       echo pull "$image" failed && exit 1
     fi
@@ -388,20 +395,22 @@ prepare_rancher() {
   for n in $rancher_all_image
   do
     if ! podman images "$n" | grep -q "${n%:*}"; then
-      if ! podman pull registry.rancher.com/"$n" &>> "${Command_Output_log_file}"; then
+      if ! logged_run "rancher retry pull $n" podman pull registry.rancher.com/"$n"; then
         echo pull "$n" failed twice && exit 1
       fi
     else
-      podman tag "${n}" "${Private_Registry_Name}"/rancher/"${n##*/}" &>> "${Command_Output_log_file}"
+      logged_run "rancher retry tag $n" podman tag "${n}" "${Private_Registry_Name}"/rancher/"${n##*/}"
       [[ "$?" != "0" ]] && echo "tag ${Private_Registry_Name}/rancher/${n##*/} Container images failed" && exit 1
     fi
   done
 
+  # save 為 pipe，用 bash -c + pipefail 包進 logged_run
   rename_rancher_all_image=$(cat rancher-images.txt | sed "s|^|${Private_Registry_Name}/|" | tr '\n' ' ')
-  podman save -m $rename_rancher_all_image | gzip --stdout > rancher-"${Rancher_Version}"-image.tar.gz
+  logged_run "rancher: save images tar.gz" bash -c "set -o pipefail; podman save -m ${rename_rancher_all_image} | gzip --stdout > rancher-${Rancher_Version}-image.tar.gz"
   [[ (( $(stat -c%s rancher-"${Rancher_Version}"-image.tar.gz) -lt 50000000 )) ]] && echo "Podman Save rancher ${Rancher_Version} images failed" && exit 1
 
-  cd ../..; tar -czf compressed_files/rancher-airgap-"${Rancher_Version}".tar.gz rancher/"${Rancher_Version}" &>> "${Command_Output_log_file}"
+  cd ../..
+  logged_run "rancher: tar airgap bundle" tar -czf compressed_files/rancher-airgap-"${Rancher_Version}".tar.gz rancher/"${Rancher_Version}"
   if [[ "$?" != "0" ]]; then
     echo "Preparing Rancher "${Rancher_Version}" Air Gap installer failed" && exit 1
   else
@@ -418,16 +427,18 @@ prepare_k3s() {
   # 切換工作目錄
   cd ~/work/k3s/"${K3S_Version}"
 
-  curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s-airgap-images-amd64.tar &>> "${Command_Output_log_file}"
+  logged_run "k3s: download k3s-airgap-images-amd64.tar" curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s-airgap-images-amd64.tar
   [[ "$?" != "0" ]] && echo "Download k3s-airgap-images-amd64.tar ${K3S_Version} failed" && exit 1
 
-  curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s &>> "${Command_Output_log_file}"
+  logged_run "k3s: download k3s binary" curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s
   [[ "$?" != "0" ]] && echo "Download k3s Binary File ${K3S_Version} failed" && exit 1
 
-  curl -sfL https://get.k3s.io/ --output install.sh && chmod +x install.sh &>> "${Command_Output_log_file}"
+  logged_run "k3s: download install.sh" curl -sfL https://get.k3s.io/ --output install.sh
   [[ "$?" != "0" ]] && echo "Download k3s Official Installation Script failed" && exit 1
+  logged_run "k3s: chmod install.sh" chmod +x install.sh
 
-  cd ../..; tar -czf compressed_files/k3s-airgap-"${K3S_Version}".tar.gz k3s/"${K3S_Version}"
+  cd ../..
+  logged_run "k3s: tar airgap bundle" tar -czf compressed_files/k3s-airgap-"${K3S_Version}".tar.gz k3s/"${K3S_Version}"
   if [[ "$?" != "0" ]]; then
     echo "Preparing K3S ${K3S_Version} Air Gap installer failed" && exit 1
   else
@@ -445,22 +456,22 @@ prepare_neuvector() {
   cd ~/work/neuvector/"${Neuvector_Version}"
 
   # install helm
-  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash &>> "${Command_Output_log_file}"
+  logged_run "neuvector: install helm" bash -c 'curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash'
   [[ "$?" != "0" ]] && echo "Install helm failed" && exit 1
 
   # add repo
-  helm repo add neuvector https://neuvector.github.io/neuvector-helm/ &>> "${Command_Output_log_file}"
+  logged_run "neuvector: helm repo add" helm repo add neuvector https://neuvector.github.io/neuvector-helm/
   [[ "$?" != "0" ]] && echo "Add Neuvector Helm Repo failed" && exit 1
 
   # update local chart
-  helm repo update &>> "${Command_Output_log_file}"
+  logged_run "neuvector: helm repo update" helm repo update
   [[ "$?" != "0" ]] && echo "Update Neuvector Helm Repo failed" && exit 1
 
-  # get specify chart version
+  # get specify chart version（複雜 pipe，輸出結果賦值回變數；不包 logged_run）
   Chart_Version=$(helm search repo neuvector/core --versions | grep "${Neuvector_Version}" | head -n 1 | fmt -u | cut -d " " -f 2)
 
   # pull
-  helm pull neuvector/core --version "${Chart_Version}" &>> "${Command_Output_log_file}"
+  logged_run "neuvector: helm pull core ${Chart_Version}" helm pull neuvector/core --version "${Chart_Version}"
   [[ "$?" != "0" ]] && echo "Pull Neuvector ${Neuvector_Version} Helm packages failed" && exit 1
 
   # create image list
@@ -473,16 +484,18 @@ prepare_neuvector() {
   do
     idx=$((idx + 1))
     print_progress "neuvector" "$idx" "$neuvector_total" "$image"
-    podman pull "$image" &>> "${Command_Output_log_file}"
+    logged_run "neuvector [$idx/$neuvector_total] pull $image" podman pull "$image"
     [[ "$?" != "0" ]] && { printf "\n" >/dev/tty 2>/dev/null; echo "Pull $image failed"; exit 1; }
   done
   printf "\n" >/dev/tty 2>/dev/null || true
 
-  # save images to tar.gz
-  podman save -m $(cat images-list.txt) | gzip --stdout > neuvector-images-"${Neuvector_Version}".tar.gz
+  # save images to tar.gz（pipe 用 bash -c + pipefail 包）
+  neuvector_all_images=$(tr '\n' ' ' < images-list.txt)
+  logged_run "neuvector: save images tar.gz" bash -c "set -o pipefail; podman save -m ${neuvector_all_images} | gzip --stdout > neuvector-images-${Neuvector_Version}.tar.gz"
   [[ "$?" != "0" ]] && echo "Podman save Neuvector images ${Neuvector_Version} failed" && exit 1
 
-  cd ../..; tar -czf compressed_files/neuvector-airgap-"${Neuvector_Version}".tar.gz neuvector/"${Neuvector_Version}"
+  cd ../..
+  logged_run "neuvector: tar airgap bundle" tar -czf compressed_files/neuvector-airgap-"${Neuvector_Version}".tar.gz neuvector/"${Neuvector_Version}"
   if [[ "$?" != "0" ]]; then
     echo "Preparing Neuvector Air Gap installer failed" && exit 1
   else

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -68,6 +68,14 @@ Environment variables:
      定義 K3S 的版本
      預設是 'v1.35.3'。
 
+   - K3S_Revision
+     定義 K3S 的 revision 後綴
+     預設是 'k3s1'。
+
+   - K3S_Source_URL
+     定義下載 K3S airgap artifact 的來源 URL
+     預設是 'https://prime.ribs.rancher.io'（Rancher Prime Artifacts）。
+
    - Neuvector_Version
      定義 Neuvector 的版本
      預設是 '5.5.0'。
@@ -167,6 +175,16 @@ setup_env() {
   # make sure the version of the K3S is defined
   if [[ -z "${K3S_Version}" ]]; then
     K3S_Version="v1.35.3"
+  fi
+
+  # make sure the revision of the K3S is defined
+  if [[ -z "${K3S_Revision}" ]]; then
+    K3S_Revision="k3s1"
+  fi
+
+  # make sure the URL of the K3S source is defined
+  if [[ -z "${K3S_Source_URL}" ]]; then
+    K3S_Source_URL="https://prime.ribs.rancher.io"
   fi
 
   # make sure the version of the Neuvector is defined
@@ -493,10 +511,10 @@ prepare_k3s() {
   cd ~/work/k3s/"${K3S_Version}"
 
   # -sSL：silent + show-error + follow-redirect，去掉 -# 的 hash progress bar
-  logged_run "k3s: download k3s-airgap-images-amd64.tar" curl -sSL -O https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s-airgap-images-amd64.tar
+  logged_run "k3s: download k3s-airgap-images-amd64.tar" curl -sSL -O "${K3S_Source_URL}"/k3s/"${K3S_Version}"%2B"${K3S_Revision}"/k3s-airgap-images-amd64.tar
   [[ "$?" != "0" ]] && echo "Download k3s-airgap-images-amd64.tar ${K3S_Version} failed" && exit 1
 
-  logged_run "k3s: download k3s binary" curl -sSL -O https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s
+  logged_run "k3s: download k3s binary" curl -sSL -O "${K3S_Source_URL}"/k3s/"${K3S_Version}"%2B"${K3S_Revision}"/k3s
   [[ "$?" != "0" ]] && echo "Download k3s Binary File ${K3S_Version} failed" && exit 1
 
   logged_run "k3s: download install.sh" curl -sfL https://get.k3s.io/ --output install.sh

--- a/podman-prepare.sh
+++ b/podman-prepare.sh
@@ -49,7 +49,11 @@ Environment variables:
 
    - Rancher_Version
      定義 Rancher 的版本
-     預設是 'v2.14.0'。
+     預設是 'v2.13.4'。
+
+   - Rancher_Source_URL
+     定義下載 Rancher airgap artifact 的來源 URL
+     預設是 'https://prime.ribs.rancher.io'（Rancher Prime Artifacts）。
 
    - Helm_Version
      定義 Helm 的版本
@@ -141,7 +145,12 @@ setup_env() {
 
   # make sure the version of the Rancher is defined
   if [[ -z "${Rancher_Version}" ]]; then
-    Rancher_Version="v2.14.0"
+    Rancher_Version="v2.13.4"
+  fi
+
+  # make sure the URL of the Rancher source is defined
+  if [[ -z "${Rancher_Source_URL}" ]]; then
+    Rancher_Source_URL="https://prime.ribs.rancher.io"
   fi
 
   # make sure the version of the Helm is defined
@@ -285,7 +294,7 @@ prepare_rancher() {
   # 下載 Rancher Images List 文字檔及蒐集 Image 所需的 Shell Script
   for x in rancher-images.txt rancher-load-images.sh rancher-save-images.sh
   do
-    wget -q https://github.com/rancher/rancher/releases/download/"${Rancher_Version}"/"${x}" &>> "${Command_Output_log_file}"
+    wget -q "${Rancher_Source_URL}"/rancher/"${Rancher_Version}"/"${x}" &>> "${Command_Output_log_file}"
     [[ "$?" != "0" ]] && echo "Download ${x} failed" && exit 1
   done
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -5,6 +5,7 @@
 [[ -z "${Command_log_file}" ]] && Command_log_file="/tmp/prepare_message.log"
 [[ -f "${Command_log_file}" ]] && sudo rm "${Command_log_file}"
 exec {BASH_XTRACEFD}>>"${Command_log_file}"
+export PS4='+ [$(date +%H:%M:%S)] ${BASH_SOURCE##*/}:${LINENO}: '
 set -x
 
 ## 預設確保命令執行後的輸出重定向到 /tmp/prepare_output_message.log 檔案中
@@ -192,6 +193,38 @@ run_step() {
   local rc=${PIPESTATUS[0]}
   [[ $rc -ne 0 ]] && exit $rc
   return 0
+}
+
+# 在合併 log 檔寫一個醒目的 section 分隔符，用來標記 prepare_* 函式的進入與結束
+log_section() {
+  local label="$1"
+  local ts; ts=$(date '+%Y-%m-%d %H:%M:%S')
+  {
+    echo ""
+    echo "############################################################"
+    echo "# [$ts] $label"
+    echo "############################################################"
+    echo ""
+  } >> "${Command_Output_log_file}"
+}
+
+# 執行外部命令並把 CMD／輸出／EXIT 一起結構化寫入合併 log 檔（不上螢幕）。
+# 使用：logged_run "<label>" <cmd> <args...>
+# 回傳值為原命令的 exit code，呼叫端既有 `[[ "$?" != "0" ]] && echo ... && exit 1` 仍適用。
+logged_run() {
+  local label="$1"; shift
+  local log="${Command_Output_log_file}"
+  local ts_start; ts_start=$(date '+%Y-%m-%d %H:%M:%S')
+  {
+    echo ""
+    echo "=== [$ts_start] $label ==="
+    echo "CMD: $*"
+  } >> "$log"
+  "$@" >> "$log" 2>&1
+  local rc=$?
+  local ts_end; ts_end=$(date '+%Y-%m-%d %H:%M:%S')
+  echo "=== [$ts_end] EXIT: $rc ===" >> "$log"
+  return $rc
 }
 
 # 建立工作目錄

--- a/prepare.sh
+++ b/prepare.sh
@@ -179,6 +179,11 @@ setup_env() {
   fi
 }
 
+# 印進度列到終端（同一行覆寫），非 TTY 時靜默
+print_progress() {
+  printf "\r\033[K[%s %d/%d] %s" "$1" "$2" "$3" "$4" >/dev/tty 2>/dev/null || true
+}
+
 # 建立工作目錄
 create_working_directory() {
   setup_env
@@ -283,16 +288,24 @@ prepare_rancher() {
   [[ "$?" != "0" ]] && echo "Download Cert_Manager CRD failed" && exit 1
 
   # 處理 cert-manager 的 Container Images
-  for i in $(helm template cert-manager-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed -e 's/\"//g')
+  # 先計算 cert-manager 所需 image 總量，作為進度列的分母
+  cert_manager_images=$(helm template cert-manager-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed -e 's/\"//g')
+  cert_manager_total=$(echo "$cert_manager_images" | wc -l)
+  idx=0
+  for image in $cert_manager_images
   do
+    idx=$((idx + 1))
+    print_progress "cert-manager" "$idx" "$cert_manager_total" "$image"
+
     # 下載 cert-manager 的 Container Images
-    sudo docker pull "$i" &>> "${Command_Output_log_file}"
-    [[ "$?" != "0" ]] && echo "Pull quay.io/jetstack/$i Container images failed" && exit 1
+    sudo docker pull "$image" &>> "${Command_Output_log_file}"
+    [[ "$?" != "0" ]] && { printf "\n" >/dev/tty 2>/dev/null; echo "Pull quay.io/jetstack/$image Container images failed"; exit 1; }
 
     # 修改 cert-manager 的所有 Container Images Tag
-    sudo docker tag "${i}" "${Private_Registry_Name}"/rancher/"${i##*/}" &>> "${Command_Output_log_file}"
-    [[ "$?" != "0" ]] && echo "tag ${Private_Registry_Name}/rancher/${i##*/} Container images failed" && exit 1
+    sudo docker tag "${image}" "${Private_Registry_Name}"/rancher/"${image##*/}" &>> "${Command_Output_log_file}"
+    [[ "$?" != "0" ]] && { printf "\n" >/dev/tty 2>/dev/null; echo "tag ${Private_Registry_Name}/rancher/${image##*/} Container images failed"; exit 1; }
   done
+  printf "\n" >/dev/tty 2>/dev/null || true
 
   # 將 cert-manager 的所有 Container Images 打包成 .tar.gz 壓縮檔
   sudo docker save $(helm template cert-manager-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed -e 's/\"//g' | sed "s|quay.io/jetstack|${Private_Registry_Name}/rancher|g") | gzip --stdout > cert-manager-image-"${Cert_Manager_Version}".tar.gz
@@ -314,12 +327,18 @@ prepare_rancher() {
 
   [[ "$?" == "0" ]] && echo "Start pulling and saving rancher ${Rancher_Version} images in the background..."
   # 下載離線安裝 Rancher 所需的所有 Container Images 並打包成 rancher-images.tar.gz
+  rancher_total=$(wc -l < rancher-images.txt)
+  idx=0
   while read image
   do
+    idx=$((idx + 1))
+    print_progress "rancher" "$idx" "$rancher_total" "$image"
     if ! sudo docker pull registry.rancher.com/"${image}" &>> "${Command_Output_log_file}"; then
+      printf "\n" >/dev/tty 2>/dev/null || true
       echo pull "$image" failed && exit 1
     fi
   done <<< $(cat rancher-images.txt)
+  printf "\n" >/dev/tty 2>/dev/null || true
 
   rancher_all_image=$(cat rancher-images.txt | sed 's|^|registry.rancher.com/|' | tr '\n' ' ')
   for n in $rancher_all_image
@@ -404,11 +423,16 @@ prepare_neuvector() {
   helm template core-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed -e 's/\"//g' > images-list.txt 2>> "${Command_Output_log_file}"
 
   # get images
-  for i in $(cat images-list.txt)
+  neuvector_total=$(wc -l < images-list.txt)
+  idx=0
+  for image in $(cat images-list.txt)
   do
-    sudo docker pull $i &>> "${Command_Output_log_file}"
-    [[ "$?" != "0" ]] && echo "Pull $i failed" && exit 1
+    idx=$((idx + 1))
+    print_progress "neuvector" "$idx" "$neuvector_total" "$image"
+    sudo docker pull "$image" &>> "${Command_Output_log_file}"
+    [[ "$?" != "0" ]] && { printf "\n" >/dev/tty 2>/dev/null; echo "Pull $image failed"; exit 1; }
   done
+  printf "\n" >/dev/tty 2>/dev/null || true
 
   # save images to tar.gz
   sudo docker save $(cat images-list.txt) | gzip --stdout > neuvector-images-"${Neuvector_Version}".tar.gz

--- a/prepare.sh
+++ b/prepare.sh
@@ -244,12 +244,12 @@ prepare_harbor() {
   # 切換工作目錄
   cd ~/work/harbor/"${Harbor_Version}"
 
-  # 下載 Harbor 壓縮檔（-nv：non-verbose，避免 dots 進度條灌 log，保留 "saved to" 摘要）
-  logged_run "harbor: download offline-installer tgz" wget -nv https://github.com/goharbor/harbor/releases/download/"${Harbor_Version}"/harbor-offline-installer-"${Harbor_Version}".tgz
+  # 下載 Harbor 壓縮檔（-nv：non-verbose；-O：顯式覆寫同名檔，避免重跑時產生 *.1）
+  logged_run "harbor: download offline-installer tgz" wget -nv -O harbor-offline-installer-"${Harbor_Version}".tgz https://github.com/goharbor/harbor/releases/download/"${Harbor_Version}"/harbor-offline-installer-"${Harbor_Version}".tgz
   [[ "$?" != "0" ]] && echo "Download harbor-offline-installer-"${Harbor_Version}".tgz failed" && exit 1
 
-  # 下載 Docker Compose 套件
-  logged_run "harbor: download docker-compose" wget -nv https://github.com/docker/compose/releases/download/"${Docker_Compose_Version}"/docker-compose-linux-x86_64
+  # 下載 Docker Compose 套件（-O 同上原因）
+  logged_run "harbor: download docker-compose" wget -nv -O docker-compose-linux-x86_64 https://github.com/docker/compose/releases/download/"${Docker_Compose_Version}"/docker-compose-linux-x86_64
   [[ "$?" != "0" ]] && echo "Download docker-compose-linux-x86_64 "${Docker_Compose_Version}" failed" && exit 1
 
   # 將以上離線安裝 Harbor 所需之套件壓縮成一個檔案
@@ -372,9 +372,11 @@ prepare_rancher() {
   [[ "$?" != "0" ]] && echo "Download helm ${Helm_Version} failed"
 
   # 下載 Rancher Images List 文字檔及蒐集 Image 所需的 Shell Script
+  # -O "${x}"：顯式覆寫同名檔，避免重跑時產生 *.1；舊檔殘留會讓下游 sort -u
+  # 作用在錯的檔（變成前次的 image list），打包出錯到的 tarball
   for x in rancher-images.txt rancher-load-images.sh rancher-save-images.sh
   do
-    logged_run "rancher: download $x" wget -q "${Rancher_Source_URL}"/rancher/"${Rancher_Version}"/"${x}"
+    logged_run "rancher: download $x" wget -q -O "${x}" "${Rancher_Source_URL}"/rancher/"${Rancher_Version}"/"${x}"
     [[ "$?" != "0" ]] && echo "Download ${x} failed" && exit 1
   done
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -236,6 +236,7 @@ create_working_directory() {
 # 準備 Harbor 全離線安裝包
 prepare_harbor() {
   setup_env
+  log_section "prepare_harbor START (Harbor_Version=${Harbor_Version})"
 
   # 清除本產品前次產出的離線安裝包，避免與本次新版並存
   rm -f ~/work/compressed_files/harbor-offline-*.tar.gz
@@ -259,11 +260,13 @@ prepare_harbor() {
   else
     echo "Prepare Harbor "${Harbor_Version}" OK."
   fi
+  log_section "prepare_harbor END"
 }
 
 # 準備 RKE2 全離線安裝包
 prepare_rke2() {
   setup_env
+  log_section "prepare_rke2 START (RKE2_Version=${RKE2_Version}, RKE2_Revision=${RKE2_Revision})"
 
   # 清除本產品前次產出的離線安裝包，避免與本次新版並存
   rm -f ~/work/compressed_files/rke2-airgap-*.tar.gz
@@ -294,12 +297,14 @@ prepare_rke2() {
   else
     echo "Prepare RKE2 "${RKE2_Version}" OK."
   fi
+  log_section "prepare_rke2 END"
 }
 
 # 準備 Rancher Prime 全離線安裝包
 prepare_rancher() {
 
   setup_env
+  log_section "prepare_rancher START (Rancher_Version=${Rancher_Version})"
 
   # 清除本產品前次產出的離線安裝包，避免與本次新版並存
   rm -f ~/work/compressed_files/rancher-airgap-*.tar.gz
@@ -416,10 +421,12 @@ prepare_rancher() {
   else
     echo "Prepare Rancher "${Rancher_Version}" OK."
   fi
+  log_section "prepare_rancher END"
 }
 
 prepare_k3s() {
   setup_env
+  log_section "prepare_k3s START (K3S_Version=${K3S_Version})"
 
   # 清除本產品前次產出的離線安裝包，避免與本次新版並存
   rm -f ~/work/compressed_files/k3s-airgap-*.tar.gz
@@ -444,10 +451,12 @@ prepare_k3s() {
   else
     echo "Prepare K3S "${K3S_Version}" OK."
   fi
+  log_section "prepare_k3s END"
 }
 
 prepare_neuvector() {
   setup_env
+  log_section "prepare_neuvector START (Neuvector_Version=${Neuvector_Version})"
 
   # 清除本產品前次產出的離線安裝包，避免與本次新版並存
   rm -f ~/work/compressed_files/neuvector-airgap-*.tar.gz
@@ -501,6 +510,7 @@ prepare_neuvector() {
   else
     echo "Prepare Neuvector ${Neuvector_Version} OK."
   fi
+  log_section "prepare_neuvector END"
 }
 
 while [[ "$#" -gt "0" ]]

--- a/prepare.sh
+++ b/prepare.sh
@@ -114,7 +114,7 @@ setup_env() {
   for command in wget curl docker
   do
     if ! which $command &> /dev/null; then
-      echo "${Command} command not found!" && exit 1
+      echo "${command} command not found!" && exit 1
     fi
   done
 
@@ -318,7 +318,8 @@ prepare_rancher() {
   printf "\n" >/dev/tty 2>/dev/null || true
 
   # 將 cert-manager 的所有 Container Images 打包成 .tar.gz 壓縮檔
-  sudo docker save $(helm template cert-manager-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed -e 's/\"//g' | sed "s|quay.io/jetstack|${Private_Registry_Name}/rancher|g") | gzip --stdout > cert-manager-image-"${Cert_Manager_Version}".tar.gz
+  # 復用前面計算好的 $cert_manager_images，避免重新跑一次 helm template
+  sudo docker save $(echo "$cert_manager_images" | sed "s|quay.io/jetstack|${Private_Registry_Name}/rancher|g") | gzip --stdout > cert-manager-image-"${Cert_Manager_Version}".tar.gz
   [[ "$?" != "0" ]] && echo "Docker save Cert-manager ${Cert_Manager_Version} images failed" && exit 1
 
   # 下載 Helm 壓縮檔
@@ -387,7 +388,7 @@ prepare_k3s() {
   curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s-airgap-images-amd64.tar &>> "${Command_Output_log_file}"
   [[ "$?" != "0" ]] && echo "Download k3s-airgap-images-amd64.tar ${K3S_Version} failed" && exit 1
 
-  curl -# -OL https://github.com/k3s-io/k3s/releases/download/"{K3S_Version}"%2Bk3s1/k3s &>> "${Command_Output_log_file}"
+  curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s &>> "${Command_Output_log_file}"
   [[ "$?" != "0" ]] && echo "Download k3s Binary File ${K3S_Version} failed" && exit 1
 
   curl -sfL https://get.k3s.io/ --output install.sh && chmod +x install.sh &>> "${Command_Output_log_file}"

--- a/prepare.sh
+++ b/prepare.sh
@@ -340,6 +340,10 @@ prepare_rancher() {
   logged_run "rancher: download cert-manager CRD" curl -sSL -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.crds.yaml
   [[ "$?" != "0" ]] && echo "Download Cert_Manager CRD failed" && exit 1
 
+  # 下載 cert-manager 官方 combined install manifest（kubectl apply 路徑用；版本跟著 ${Cert_Manager_Version}）
+  logged_run "rancher: download cert-manager manifest" curl -sSL -o cert-manager.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.yaml
+  [[ "$?" != "0" ]] && echo "Download Cert_Manager manifest failed" && exit 1
+
   # 處理 cert-manager 的 Container Images
   # 先計算 cert-manager 所需 image 總量，作為進度列的分母
   cert_manager_images=$(helm template cert-manager-*.tgz | awk '$1 ~ /image:/ {print $2}' | sed -e 's/\"//g')

--- a/prepare.sh
+++ b/prepare.sh
@@ -244,15 +244,16 @@ prepare_harbor() {
   cd ~/work/harbor/"${Harbor_Version}"
 
   # 下載 Harbor 壓縮檔
-  wget https://github.com/goharbor/harbor/releases/download/"${Harbor_Version}"/harbor-offline-installer-"${Harbor_Version}".tgz &>> "${Command_Output_log_file}"
+  logged_run "harbor: download offline-installer tgz" wget https://github.com/goharbor/harbor/releases/download/"${Harbor_Version}"/harbor-offline-installer-"${Harbor_Version}".tgz
   [[ "$?" != "0" ]] && echo "Download harbor-offline-installer-"${Harbor_Version}".tgz failed" && exit 1
 
   # 下載 Docker Compose 套件
-  wget https://github.com/docker/compose/releases/download/"${Docker_Compose_Version}"/docker-compose-linux-x86_64 &>> "${Command_Output_log_file}"
+  logged_run "harbor: download docker-compose" wget https://github.com/docker/compose/releases/download/"${Docker_Compose_Version}"/docker-compose-linux-x86_64
   [[ "$?" != "0" ]] && echo "Download docker-compose-linux-x86_64 "${Docker_Compose_Version}" failed" && exit 1
 
   # 將以上離線安裝 Harbor 所需之套件壓縮成一個檔案
-  cd ../..; tar -czvf compressed_files/harbor-offline-"${Harbor_Version}".tar.gz harbor/"${Harbor_Version}" &>> "${Command_Output_log_file}"
+  cd ../..
+  logged_run "harbor: tar airgap bundle" tar -czvf compressed_files/harbor-offline-"${Harbor_Version}".tar.gz harbor/"${Harbor_Version}"
   if [[ "$?" != "0" ]]; then
     echo "Preparing harbor full Air Gap installer failed" && exit 1
   else
@@ -271,21 +272,23 @@ prepare_rke2() {
   cd ~/work/rke2/"${RKE2_Version}"
 
   # 下載離線安裝 RKE2 所需 Image 之壓縮檔
-  curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/rke2-images.linux-amd64.tar.zst &>> "${Command_Output_log_file}"
+  logged_run "rke2: download rke2-images.linux-amd64.tar.zst" curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/rke2-images.linux-amd64.tar.zst
   [[ "$?" != "0" ]] && echo "Download rke2-images.linux-amd64.tar.zst "${RKE2_Version}" failed" && exit 1
 
-  curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/rke2.linux-amd64.tar.gz &>> "${Command_Output_log_file}"
+  logged_run "rke2: download rke2.linux-amd64.tar.gz" curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/rke2.linux-amd64.tar.gz
   [[ "$?" != "0" ]] && echo "Download rke2.linux-amd64.tar.gz "${RKE2_Version}" failed" && exit 1
 
-  curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/sha256sum-amd64.txt &>> "${Command_Output_log_file}"
+  logged_run "rke2: download sha256sum-amd64.txt" curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/sha256sum-amd64.txt
   [[ "$?" != "0" ]] && echo "Download sha256sum-amd64.txt "${RKE2_Version}" failed" && exit 1
 
   # 下載官網提供的離線安裝 RKE2 所需之安裝腳本，並賦予它執行權限
-  curl -sfL https://get.rke2.io --output install.sh && chmod +x install.sh &>> "${Command_Output_log_file}"
+  logged_run "rke2: download install.sh" curl -sfL https://get.rke2.io --output install.sh
   [[ "$?" != "0" ]] && echo "Download rke2 install.sh failed" && exit 1
+  logged_run "rke2: chmod install.sh" chmod +x install.sh
 
   # 將以上離線安裝 RKE2 所需之檔案，壓縮成一個檔案
-  cd ../..; tar -czvf compressed_files/rke2-airgap-"${RKE2_Version}".tar.gz rke2/"${RKE2_Version}" &>> "${Command_Output_log_file}"
+  cd ../..
+  logged_run "rke2: tar airgap bundle" tar -czvf compressed_files/rke2-airgap-"${RKE2_Version}".tar.gz rke2/"${RKE2_Version}"
   if [[ "$?" != "0" ]]; then
     echo "Preparing RKE2 Air Gap installer failed" && exit 1
   else
@@ -305,29 +308,31 @@ prepare_rancher() {
   cd ~/work/rancher/"${Rancher_Version}"
 
   # 安裝 helm
-  curl -s https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash &>> "${Command_Output_log_file}"
+  logged_run "rancher: install helm" bash -c 'curl -s https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash'
   [[ "$?" != "0" ]] && echo "Install helm failed" && exit 1
 
   # 新增並刷新 Rancher Prime 的 Helm Chart Repository
-  helm repo add rancher-prime https://charts.rancher.com/server-charts/prime &>> "${Command_Output_log_file}" && \
-  helm repo update &>> "${Command_Output_log_file}"
-  [[ "$?" != "0" ]] && echo "helm repo add or update rancher-prime failed" && exit 1
+  logged_run "rancher: helm repo add rancher-prime" helm repo add rancher-prime https://charts.rancher.com/server-charts/prime
+  [[ "$?" != "0" ]] && echo "helm repo add rancher-prime failed" && exit 1
+  logged_run "rancher: helm repo update (rancher-prime)" helm repo update
+  [[ "$?" != "0" ]] && echo "helm repo update (rancher-prime) failed" && exit 1
 
   # 下載 Rancher chart
-  helm fetch rancher-prime/rancher --version="${Rancher_Version}" &>> "${Command_Output_log_file}"
+  logged_run "rancher: helm fetch rancher chart" helm fetch rancher-prime/rancher --version="${Rancher_Version}"
   [[ "$?" != "0" ]] && echo "helm fetch rancher failed" && exit 1
 
   # 新增和刷新 cert-manager repo
-  helm repo add jetstack https://charts.jetstack.io &>> "${Command_Output_log_file}" && \
-  helm repo update &>> "${Command_Output_log_file}"
-  [[ "$?" != "0" ]] && echo "helm repo add or update cert-manager failed" && exit 1
+  logged_run "rancher: helm repo add jetstack" helm repo add jetstack https://charts.jetstack.io
+  [[ "$?" != "0" ]] && echo "helm repo add jetstack failed" && exit 1
+  logged_run "rancher: helm repo update (jetstack)" helm repo update
+  [[ "$?" != "0" ]] && echo "helm repo update (jetstack) failed" && exit 1
 
   # 下載 cert-manager chart
-  helm fetch jetstack/cert-manager --version "${Cert_Manager_Version}" &>> "${Command_Output_log_file}"
+  logged_run "rancher: helm fetch cert-manager chart" helm fetch jetstack/cert-manager --version "${Cert_Manager_Version}"
   [[ "$?" != "0" ]] && echo "helm fetch Cert_Manager failed" && exit 1
 
   # 下載 cert-manager 要求的 CRD
-  curl -L -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.crds.yaml &>> "${Command_Output_log_file}"
+  logged_run "rancher: download cert-manager CRD" curl -L -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.crds.yaml
   [[ "$?" != "0" ]] && echo "Download Cert_Manager CRD failed" && exit 1
 
   # 處理 cert-manager 的 Container Images
@@ -341,33 +346,35 @@ prepare_rancher() {
     print_progress "cert-manager" "$idx" "$cert_manager_total" "$image"
 
     # 下載 cert-manager 的 Container Images
-    sudo docker pull "$image" &>> "${Command_Output_log_file}"
+    logged_run "cert-manager [$idx/$cert_manager_total] pull $image" sudo docker pull "$image"
     [[ "$?" != "0" ]] && { printf "\n" >/dev/tty 2>/dev/null; echo "Pull quay.io/jetstack/$image Container images failed"; exit 1; }
 
     # 修改 cert-manager 的所有 Container Images Tag
-    sudo docker tag "${image}" "${Private_Registry_Name}"/rancher/"${image##*/}" &>> "${Command_Output_log_file}"
+    logged_run "cert-manager [$idx/$cert_manager_total] tag $image" sudo docker tag "${image}" "${Private_Registry_Name}"/rancher/"${image##*/}"
     [[ "$?" != "0" ]] && { printf "\n" >/dev/tty 2>/dev/null; echo "tag ${Private_Registry_Name}/rancher/${image##*/} Container images failed"; exit 1; }
   done
   printf "\n" >/dev/tty 2>/dev/null || true
 
   # 將 cert-manager 的所有 Container Images 打包成 .tar.gz 壓縮檔
   # 復用前面計算好的 $cert_manager_images，避免重新跑一次 helm template
-  sudo docker save $(echo "$cert_manager_images" | sed "s|quay.io/jetstack|${Private_Registry_Name}/rancher|g") | gzip --stdout > cert-manager-image-"${Cert_Manager_Version}".tar.gz
+  # pipe 用 bash -c 包，set -o pipefail 讓 save 或 gzip 任一段失敗都能正確回傳
+  cert_manager_renamed_images=$(echo "$cert_manager_images" | sed "s|quay.io/jetstack|${Private_Registry_Name}/rancher|g" | tr '\n' ' ')
+  logged_run "cert-manager: save images tar.gz" bash -c "set -o pipefail; sudo docker save ${cert_manager_renamed_images} | gzip --stdout > cert-manager-image-${Cert_Manager_Version}.tar.gz"
   [[ "$?" != "0" ]] && echo "Docker save Cert-manager ${Cert_Manager_Version} images failed" && exit 1
 
   # 下載 Helm 壓縮檔
-  wget -q https://get.helm.sh/helm-"${Helm_Version}"-linux-amd64.tar.gz -O helm-"${Helm_Version}"-linux-amd64.tar.gz &>> "${Command_Output_log_file}"
+  logged_run "rancher: download helm ${Helm_Version} tarball" wget -q https://get.helm.sh/helm-"${Helm_Version}"-linux-amd64.tar.gz -O helm-"${Helm_Version}"-linux-amd64.tar.gz
   [[ "$?" != "0" ]] && echo "Download helm ${Helm_Version} failed"
 
   # 下載 Rancher Images List 文字檔及蒐集 Image 所需的 Shell Script
   for x in rancher-images.txt rancher-load-images.sh rancher-save-images.sh
   do
-    wget -q "${Rancher_Source_URL}"/rancher/"${Rancher_Version}"/"${x}" &>> "${Command_Output_log_file}"
+    logged_run "rancher: download $x" wget -q "${Rancher_Source_URL}"/rancher/"${Rancher_Version}"/"${x}"
     [[ "$?" != "0" ]] && echo "Download ${x} failed" && exit 1
   done
 
   # 對 Image List 進行排序和唯一化，以消除來源之間的任何重疊
-  sort -u rancher-images.txt -o rancher-images.txt &>> "${Command_Output_log_file}"
+  logged_run "rancher: sort-uniq rancher-images.txt" sort -u rancher-images.txt -o rancher-images.txt
 
   [[ "$?" == "0" ]] && echo "Start pulling and saving rancher ${Rancher_Version} images in the background..."
   # 下載離線安裝 Rancher 所需的所有 Container Images 並打包成 rancher-images.tar.gz
@@ -377,7 +384,7 @@ prepare_rancher() {
   do
     idx=$((idx + 1))
     print_progress "rancher" "$idx" "$rancher_total" "$image"
-    if ! sudo docker pull registry.rancher.com/"${image}" &>> "${Command_Output_log_file}"; then
+    if ! logged_run "rancher [$idx/$rancher_total] pull $image" sudo docker pull registry.rancher.com/"${image}"; then
       printf "\n" >/dev/tty 2>/dev/null || true
       echo pull "$image" failed && exit 1
     fi
@@ -388,20 +395,22 @@ prepare_rancher() {
   for n in $rancher_all_image
   do
     if ! sudo docker images "$n" | grep -q "${n%:*}"; then
-      if ! sudo docker pull registry.rancher.com/"$n" &>> "${Command_Output_log_file}"; then
+      if ! logged_run "rancher retry pull $n" sudo docker pull registry.rancher.com/"$n"; then
         echo pull "$n" failed twice && exit 1
       fi
     else
-      sudo docker tag "${n}" "${Private_Registry_Name}"/rancher/"${n##*/}" &>> "${Command_Output_log_file}"
+      logged_run "rancher retry tag $n" sudo docker tag "${n}" "${Private_Registry_Name}"/rancher/"${n##*/}"
       [[ "$?" != "0" ]] && echo "tag ${Private_Registry_Name}/rancher/${n##*/} Container images failed" && exit 1
     fi
   done
 
+  # save 為 pipe，用 bash -c + pipefail 包進 logged_run
   rename_rancher_all_image=$(cat rancher-images.txt | sed "s|^|${Private_Registry_Name}/|" | tr '\n' ' ')
-  sudo docker save $rename_rancher_all_image | gzip --stdout > rancher-"${Rancher_Version}"-image.tar.gz
+  logged_run "rancher: save images tar.gz" bash -c "set -o pipefail; sudo docker save ${rename_rancher_all_image} | gzip --stdout > rancher-${Rancher_Version}-image.tar.gz"
   [[ (( $(stat -c%s rancher-"${Rancher_Version}"-image.tar.gz) -lt 50000000 )) ]] && echo "Docker Save rancher ${Rancher_Version} images failed" && exit 1
 
-  cd ../..; tar -czf compressed_files/rancher-airgap-"${Rancher_Version}".tar.gz rancher/"${Rancher_Version}" &>> "${Command_Output_log_file}"
+  cd ../..
+  logged_run "rancher: tar airgap bundle" tar -czf compressed_files/rancher-airgap-"${Rancher_Version}".tar.gz rancher/"${Rancher_Version}"
   if [[ "$?" != "0" ]]; then
     echo "Preparing Rancher "${Rancher_Version}" Air Gap installer failed" && exit 1
   else
@@ -418,16 +427,18 @@ prepare_k3s() {
   # 切換工作目錄
   cd ~/work/k3s/"${K3S_Version}"
 
-  curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s-airgap-images-amd64.tar &>> "${Command_Output_log_file}"
+  logged_run "k3s: download k3s-airgap-images-amd64.tar" curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s-airgap-images-amd64.tar
   [[ "$?" != "0" ]] && echo "Download k3s-airgap-images-amd64.tar ${K3S_Version} failed" && exit 1
 
-  curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s &>> "${Command_Output_log_file}"
+  logged_run "k3s: download k3s binary" curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s
   [[ "$?" != "0" ]] && echo "Download k3s Binary File ${K3S_Version} failed" && exit 1
 
-  curl -sfL https://get.k3s.io/ --output install.sh && chmod +x install.sh &>> "${Command_Output_log_file}"
+  logged_run "k3s: download install.sh" curl -sfL https://get.k3s.io/ --output install.sh
   [[ "$?" != "0" ]] && echo "Download k3s Official Installation Script failed" && exit 1
+  logged_run "k3s: chmod install.sh" chmod +x install.sh
 
-  cd ../..; tar -czf compressed_files/k3s-airgap-"${K3S_Version}".tar.gz k3s/"${K3S_Version}"
+  cd ../..
+  logged_run "k3s: tar airgap bundle" tar -czf compressed_files/k3s-airgap-"${K3S_Version}".tar.gz k3s/"${K3S_Version}"
   if [[ "$?" != "0" ]]; then
     echo "Preparing K3S ${K3S_Version} Air Gap installer failed" && exit 1
   else
@@ -445,22 +456,22 @@ prepare_neuvector() {
   cd ~/work/neuvector/"${Neuvector_Version}"
 
   # install helm
-  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash &>> "${Command_Output_log_file}"
+  logged_run "neuvector: install helm" bash -c 'curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash'
   [[ "$?" != "0" ]] && echo "Install helm failed" && exit 1
 
   # add repo
-  helm repo add neuvector https://neuvector.github.io/neuvector-helm/ &>> "${Command_Output_log_file}"
+  logged_run "neuvector: helm repo add" helm repo add neuvector https://neuvector.github.io/neuvector-helm/
   [[ "$?" != "0" ]] && echo "Add Neuvector Helm Repo failed" && exit 1
 
   # update local chart
-  helm repo update &>> "${Command_Output_log_file}"
+  logged_run "neuvector: helm repo update" helm repo update
   [[ "$?" != "0" ]] && echo "Update Neuvector Helm Repo failed" && exit 1
 
-  # get specify chart version
+  # get specify chart version（複雜 pipe，輸出結果賦值回變數；不包 logged_run）
   Chart_Version=$(helm search repo neuvector/core --versions | grep "${Neuvector_Version}" | head -n 1 | fmt -u | cut -d " " -f 2)
 
   # pull
-  helm pull neuvector/core --version "${Chart_Version}" &>> "${Command_Output_log_file}"
+  logged_run "neuvector: helm pull core ${Chart_Version}" helm pull neuvector/core --version "${Chart_Version}"
   [[ "$?" != "0" ]] && echo "Pull Neuvector ${Neuvector_Version} Helm packages failed" && exit 1
 
   # create image list
@@ -473,16 +484,18 @@ prepare_neuvector() {
   do
     idx=$((idx + 1))
     print_progress "neuvector" "$idx" "$neuvector_total" "$image"
-    sudo docker pull "$image" &>> "${Command_Output_log_file}"
+    logged_run "neuvector [$idx/$neuvector_total] pull $image" sudo docker pull "$image"
     [[ "$?" != "0" ]] && { printf "\n" >/dev/tty 2>/dev/null; echo "Pull $image failed"; exit 1; }
   done
   printf "\n" >/dev/tty 2>/dev/null || true
 
-  # save images to tar.gz
-  sudo docker save $(cat images-list.txt) | gzip --stdout > neuvector-images-"${Neuvector_Version}".tar.gz
+  # save images to tar.gz（pipe 用 bash -c + pipefail 包）
+  neuvector_all_images=$(tr '\n' ' ' < images-list.txt)
+  logged_run "neuvector: save images tar.gz" bash -c "set -o pipefail; sudo docker save ${neuvector_all_images} | gzip --stdout > neuvector-images-${Neuvector_Version}.tar.gz"
   [[ "$?" != "0" ]] && echo "Docker save Neuvector images ${Neuvector_Version} failed" && exit 1
 
-  cd ../..; tar -czf compressed_files/neuvector-airgap-"${Neuvector_Version}".tar.gz neuvector/"${Neuvector_Version}"
+  cd ../..
+  logged_run "neuvector: tar airgap bundle" tar -czf compressed_files/neuvector-airgap-"${Neuvector_Version}".tar.gz neuvector/"${Neuvector_Version}"
   if [[ "$?" != "0" ]]; then
     echo "Preparing Neuvector Air Gap installer failed" && exit 1
   else

--- a/prepare.sh
+++ b/prepare.sh
@@ -323,8 +323,8 @@ prepare_rancher() {
   [[ "$?" != "0" ]] && echo "helm repo update (rancher-prime) failed" && exit 1
 
   # 下載 Rancher chart
-  logged_run "rancher: helm fetch rancher chart" helm fetch rancher-prime/rancher --version="${Rancher_Version}"
-  [[ "$?" != "0" ]] && echo "helm fetch rancher failed" && exit 1
+  logged_run "rancher: helm pull rancher chart" helm pull rancher-prime/rancher --version="${Rancher_Version}"
+  [[ "$?" != "0" ]] && echo "helm pull rancher failed" && exit 1
 
   # 新增和刷新 cert-manager repo
   logged_run "rancher: helm repo add jetstack" helm repo add jetstack https://charts.jetstack.io
@@ -333,8 +333,8 @@ prepare_rancher() {
   [[ "$?" != "0" ]] && echo "helm repo update (jetstack) failed" && exit 1
 
   # 下載 cert-manager chart
-  logged_run "rancher: helm fetch cert-manager chart" helm fetch jetstack/cert-manager --version "${Cert_Manager_Version}"
-  [[ "$?" != "0" ]] && echo "helm fetch Cert_Manager failed" && exit 1
+  logged_run "rancher: helm pull cert-manager chart" helm pull jetstack/cert-manager --version "${Cert_Manager_Version}"
+  [[ "$?" != "0" ]] && echo "helm pull Cert_Manager failed" && exit 1
 
   # 下載 cert-manager 要求的 CRD（-sSL：silent + show-error + follow-redirect）
   logged_run "rancher: download cert-manager CRD" curl -sSL -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.crds.yaml

--- a/prepare.sh
+++ b/prepare.sh
@@ -184,6 +184,16 @@ print_progress() {
   printf "\r\033[K[%s %d/%d] %s" "$1" "$2" "$3" "$4" >/dev/tty 2>/dev/null || true
 }
 
+# 呼叫 function/command 並把 stdout/stderr 導入 log 檔；若呼叫者非零結束，
+# 整支腳本立即以相同 exit code 結束（用 PIPESTATUS[0] 取 pipeline 第一段狀態，
+# 避免 `prepare_* | tee` 把 function 包進 subshell 後 `exit 1` 只結束 subshell 的問題）
+run_step() {
+  "$@" 2>&1 | tee -a "${Command_Output_log_file}"
+  local rc=${PIPESTATUS[0]}
+  [[ $rc -ne 0 ]] && exit $rc
+  return 0
+}
+
 # 建立工作目錄
 create_working_directory() {
   setup_env
@@ -451,35 +461,37 @@ do
   option="$1"
   case $option in
     all)
-      create_working_directory 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_harbor 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_rke2 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_rancher 2>&1 | tee -a "${Command_Output_log_file}"
+      run_step create_working_directory
+      run_step prepare_harbor
+      run_step prepare_rke2
+      run_step prepare_rancher
+      run_step prepare_k3s
+      run_step prepare_neuvector
       exit 0
     ;;
     harbor)
-      create_working_directory 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_harbor 2>&1 | tee -a "${Command_Output_log_file}"
+      run_step create_working_directory
+      run_step prepare_harbor
       shift
     ;;
     rke2)
-      create_working_directory 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_rke2 2>&1 | tee -a "${Command_Output_log_file}"
+      run_step create_working_directory
+      run_step prepare_rke2
       shift
     ;;
     rancher)
-      create_working_directory 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_rancher 2>&1 | tee -a "${Command_Output_log_file}"
+      run_step create_working_directory
+      run_step prepare_rancher
       shift
     ;;
     k3s)
-      create_working_directory 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_k3s 2>&1 | tee -a "${Command_Output_log_file}"
+      run_step create_working_directory
+      run_step prepare_k3s
       shift
     ;;
     neuvector)
-      create_working_directory 2>&1 | tee -a "${Command_Output_log_file}"
-      prepare_neuvector 2>&1 | tee -a "${Command_Output_log_file}"
+      run_step create_working_directory
+      run_step prepare_neuvector
       shift
     ;;
     *)

--- a/prepare.sh
+++ b/prepare.sh
@@ -178,6 +178,12 @@ setup_env() {
   if [[ -z "${Private_Registry_Name}" ]]; then
     Private_Registry_Name="harbor.example.com"
   fi
+
+  # Helm 與 k8s n-3 相容性 pre-flight check；fail 時 exit 以避免打包出無法用的 airgap 包
+  if ! helm_version_skew_check; then
+    echo "[helm version skew] 版本不相容，停止執行。詳見 https://helm.sh/docs/topics/version_skew/" >&2
+    exit 1
+  fi
 }
 
 # 印進度列到終端（同一行覆寫），非 TTY 時靜默
@@ -224,6 +230,52 @@ logged_run() {
   local rc=$?
   local ts_end; ts_end=$(date '+%Y-%m-%d %H:%M:%S')
   echo "=== [$ts_end] EXIT: $rc ===" >> "$log"
+  return $rc
+}
+
+# 檢查 ${Helm_Version} compiled-against 的 k8s minor 與 ${RKE2_Version}／${K3S_Version}
+# 是否落在 Helm n-3 support window 內（https://helm.sh/docs/topics/version_skew/）。
+# 規律（v3.x 系列）：Helm 3.N 對應 k8s.io/client-go v0.(N+15) → k8s 1.(N+15)。
+# 例：v3.20 → k8s 1.35，支援 1.32 – 1.35；v3.14 → k8s 1.29，支援 1.26 – 1.29。
+# 非 v3.x（例：v4.x）目前不自動判斷，僅 echo 提示請使用者自行對照文件。
+helm_version_skew_check() {
+  local helm_ver="${Helm_Version#v}"
+  local helm_major="${helm_ver%%.*}"
+  local helm_minor_rest="${helm_ver#*.}"
+  local helm_minor="${helm_minor_rest%%.*}"
+
+  if [[ "$helm_major" != "3" ]]; then
+    echo "[helm version skew] Helm_Version=${Helm_Version} 非 v3.x，跳過自動相容性檢查；請自行對照 https://helm.sh/docs/topics/version_skew/" >&2
+    return 0
+  fi
+
+  local helm_k8s_target=$((helm_minor + 15))       # e.g. Helm 3.20 → k8s 1.35
+  local helm_k8s_min=$((helm_k8s_target - 3))      # n-3 下界，e.g. 1.32
+
+  local target_names=("RKE2" "K3S")
+  local target_vars=("${RKE2_Version}" "${K3S_Version}")
+  local rc=0
+  local i
+  for i in "${!target_vars[@]}"; do
+    local tv="${target_vars[$i]#v}"
+    local tn="${target_names[$i]}"
+    local t_major="${tv%%.*}"
+    local t_minor_rest="${tv#*.}"
+    local t_minor="${t_minor_rest%%.*}"
+
+    if [[ "$t_major" != "1" ]]; then
+      echo "[helm version skew] ${tn}_Version=${target_vars[$i]} 非 v1.x，跳過" >&2
+      continue
+    fi
+
+    if (( t_minor > helm_k8s_target )); then
+      echo "[helm version skew] ${tn}_Version=${target_vars[$i]}（k8s 1.${t_minor}）比 Helm_Version=${Helm_Version} compiled-against 的 k8s 1.${helm_k8s_target} 還新；超出 Helm 支援範圍 → 升 Helm_Version" >&2
+      rc=1
+    elif (( t_minor < helm_k8s_min )); then
+      echo "[helm version skew] ${tn}_Version=${target_vars[$i]}（k8s 1.${t_minor}）早於 Helm_Version=${Helm_Version} 的 n-3 下界 1.${helm_k8s_min} → 降 Helm_Version 或升 ${tn}_Version" >&2
+      rc=1
+    fi
+  done
   return $rc
 }
 

--- a/prepare.sh
+++ b/prepare.sh
@@ -189,6 +189,9 @@ create_working_directory() {
 prepare_harbor() {
   setup_env
 
+  # 清除本產品前次產出的離線安裝包，避免與本次新版並存
+  rm -f ~/work/compressed_files/harbor-offline-*.tar.gz
+
   # 切換工作目錄
   cd ~/work/harbor/"${Harbor_Version}"
 
@@ -212,6 +215,10 @@ prepare_harbor() {
 # 準備 RKE2 全離線安裝包
 prepare_rke2() {
   setup_env
+
+  # 清除本產品前次產出的離線安裝包，避免與本次新版並存
+  rm -f ~/work/compressed_files/rke2-airgap-*.tar.gz
+
   # 切換工作目錄
   cd ~/work/rke2/"${RKE2_Version}"
 
@@ -242,6 +249,10 @@ prepare_rke2() {
 prepare_rancher() {
 
   setup_env
+
+  # 清除本產品前次產出的離線安裝包，避免與本次新版並存
+  rm -f ~/work/compressed_files/rancher-airgap-*.tar.gz
+
   # 切換工作目錄
   cd ~/work/rancher/"${Rancher_Version}"
 
@@ -338,6 +349,9 @@ prepare_rancher() {
 prepare_k3s() {
   setup_env
 
+  # 清除本產品前次產出的離線安裝包，避免與本次新版並存
+  rm -f ~/work/compressed_files/k3s-airgap-*.tar.gz
+
   # 切換工作目錄
   cd ~/work/k3s/"${K3S_Version}"
 
@@ -360,6 +374,9 @@ prepare_k3s() {
 
 prepare_neuvector() {
   setup_env
+
+  # 清除本產品前次產出的離線安裝包，避免與本次新版並存
+  rm -f ~/work/compressed_files/neuvector-airgap-*.tar.gz
 
   # 切換工作目錄
   cd ~/work/neuvector/"${Neuvector_Version}"

--- a/prepare.sh
+++ b/prepare.sh
@@ -39,6 +39,14 @@ Environment variables:
      定義 RKE2 的版本
      預設是 'v1.27.11'。
 
+   - RKE2_Revision
+     定義 RKE2 的 revision 後綴
+     預設是 'rke2r1'。
+
+   - RKE2_Source_URL
+     定義下載 RKE2 airgap artifact 的來源 URL
+     預設是 'https://prime.ribs.rancher.io'（Rancher Prime Artifacts）。
+
    - Rancher_Version
      定義 Rancher 的版本
      預設是 'v2.8.2'。
@@ -121,6 +129,16 @@ setup_env() {
     RKE2_Version="v1.27.11"
   fi
 
+  # make sure the revision of the RKE2 is defined
+  if [[ -z "${RKE2_Revision}" ]]; then
+    RKE2_Revision="rke2r1"
+  fi
+
+  # make sure the URL of the RKE2 source is defined
+  if [[ -z "${RKE2_Source_URL}" ]]; then
+    RKE2_Source_URL="https://prime.ribs.rancher.io"
+  fi
+
   # make sure the version of the Rancher is defined
   if [[ -z "${Rancher_Version}" ]]; then
     Rancher_Version="v2.8.2"
@@ -189,13 +207,13 @@ prepare_rke2() {
   cd ~/work/rke2/"${RKE2_Version}"
 
   # 下載離線安裝 RKE2 所需 Image 之壓縮檔
-  curl -s -OL https://github.com/rancher/rke2/releases/download/"${RKE2_Version}"%2Brke2r1/rke2-images.linux-amd64.tar.zst &>> "${Command_Output_log_file}"
+  curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/rke2-images.linux-amd64.tar.zst &>> "${Command_Output_log_file}"
   [[ "$?" != "0" ]] && echo "Download rke2-images.linux-amd64.tar.zst "${RKE2_Version}" failed" && exit 1
 
-  curl -s -OL https://github.com/rancher/rke2/releases/download/"${RKE2_Version}"%2Brke2r1/rke2.linux-amd64.tar.gz &>> "${Command_Output_log_file}"
+  curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/rke2.linux-amd64.tar.gz &>> "${Command_Output_log_file}"
   [[ "$?" != "0" ]] && echo "Download rke2.linux-amd64.tar.gz "${RKE2_Version}" failed" && exit 1
 
-  curl -s -OL https://github.com/rancher/rke2/releases/download/"${RKE2_Version}"%2Brke2r1/sha256sum-amd64.txt &>> "${Command_Output_log_file}"
+  curl -s -OL "${RKE2_Source_URL}"/rke2/"${RKE2_Version}"%2B"${RKE2_Revision}"/sha256sum-amd64.txt &>> "${Command_Output_log_file}"
   [[ "$?" != "0" ]] && echo "Download sha256sum-amd64.txt "${RKE2_Version}" failed" && exit 1
 
   # 下載官網提供的離線安裝 RKE2 所需之安裝腳本，並賦予它執行權限

--- a/prepare.sh
+++ b/prepare.sh
@@ -29,19 +29,19 @@ Environment variables:
 
    - Harbor_Version
      定義 Harbor 的版本
-     預設是 'v2.10.0'。
+     預設是 'v2.15.0'。
 
    - Docker_Compose_Version
      定義 docker-compose 的版本
-     預設是 'v2.24.7'。
+     預設是 'v2.40.3'。
 
    - RKE2_Version
      定義 RKE2 的版本
-     預設是 'v1.27.11'。
+     預設是 'v1.35.3'。
 
    - RKE2_Revision
      定義 RKE2 的 revision 後綴
-     預設是 'rke2r1'。
+     預設是 'rke2r3'。
 
    - RKE2_Source_URL
      定義下載 RKE2 airgap artifact 的來源 URL
@@ -49,11 +49,11 @@ Environment variables:
 
    - Rancher_Version
      定義 Rancher 的版本
-     預設是 'v2.8.2'。
+     預設是 'v2.14.0'。
 
    - Helm_Version
      定義 Helm 的版本
-     預設是 'v3.14.2'。
+     預設是 'v3.20.2'。
 
    - Cert_Manager_Version
      定義 Cert-manager 的版本
@@ -61,11 +61,11 @@ Environment variables:
 
    - K3S_Version
      定義 K3S 的版本
-     預設是 'v1.27.11'。
+     預設是 'v1.35.3'。
 
    - Neuvector_Version
      定義 Neuvector 的版本
-     預設是 '5.3.0'。
+     預設是 '5.5.0'。
 
    - Private_Registry_Name
      定義企業內部私有 Image Registry 的名稱
@@ -116,22 +116,22 @@ setup_env() {
 
   # make sure the version of the Harbor is defined
   if [[ -z "${Harbor_Version}" ]]; then
-    Harbor_Version="v2.10.0"
+    Harbor_Version="v2.15.0"
   fi
 
   # make sure the version of the Docker-compose is defined
   if [[ -z "${Docker_Compose_Version}" ]]; then
-    Docker_Compose_Version="v2.24.7"
+    Docker_Compose_Version="v2.40.3"
   fi
 
   # make sure the version of the RKE2 is defined
   if [[ -z "${RKE2_Version}" ]]; then
-    RKE2_Version="v1.27.11"
+    RKE2_Version="v1.35.3"
   fi
 
   # make sure the revision of the RKE2 is defined
   if [[ -z "${RKE2_Revision}" ]]; then
-    RKE2_Revision="rke2r1"
+    RKE2_Revision="rke2r3"
   fi
 
   # make sure the URL of the RKE2 source is defined
@@ -141,12 +141,12 @@ setup_env() {
 
   # make sure the version of the Rancher is defined
   if [[ -z "${Rancher_Version}" ]]; then
-    Rancher_Version="v2.8.2"
+    Rancher_Version="v2.14.0"
   fi
 
   # make sure the version of the Helm is defined
   if [[ -z "${Helm_Version}" ]]; then
-    Helm_Version="v3.14.2"
+    Helm_Version="v3.20.2"
   fi
 
   # make sure the version of the Cert-Manager is defined
@@ -156,12 +156,12 @@ setup_env() {
 
   # make sure the version of the K3S is defined
   if [[ -z "${K3S_Version}" ]]; then
-    K3S_Version="v1.27.11"
+    K3S_Version="v1.35.3"
   fi
 
   # make sure the version of the Neuvector is defined
   if [[ -z "${Neuvector_Version}" ]]; then
-    Neuvector_Version="5.3.0"
+    Neuvector_Version="5.5.0"
   fi
 
   # make sure the name of the Private Images Registry is defined

--- a/prepare.sh
+++ b/prepare.sh
@@ -244,12 +244,12 @@ prepare_harbor() {
   # 切換工作目錄
   cd ~/work/harbor/"${Harbor_Version}"
 
-  # 下載 Harbor 壓縮檔
-  logged_run "harbor: download offline-installer tgz" wget https://github.com/goharbor/harbor/releases/download/"${Harbor_Version}"/harbor-offline-installer-"${Harbor_Version}".tgz
+  # 下載 Harbor 壓縮檔（-nv：non-verbose，避免 dots 進度條灌 log，保留 "saved to" 摘要）
+  logged_run "harbor: download offline-installer tgz" wget -nv https://github.com/goharbor/harbor/releases/download/"${Harbor_Version}"/harbor-offline-installer-"${Harbor_Version}".tgz
   [[ "$?" != "0" ]] && echo "Download harbor-offline-installer-"${Harbor_Version}".tgz failed" && exit 1
 
   # 下載 Docker Compose 套件
-  logged_run "harbor: download docker-compose" wget https://github.com/docker/compose/releases/download/"${Docker_Compose_Version}"/docker-compose-linux-x86_64
+  logged_run "harbor: download docker-compose" wget -nv https://github.com/docker/compose/releases/download/"${Docker_Compose_Version}"/docker-compose-linux-x86_64
   [[ "$?" != "0" ]] && echo "Download docker-compose-linux-x86_64 "${Docker_Compose_Version}" failed" && exit 1
 
   # 將以上離線安裝 Harbor 所需之套件壓縮成一個檔案
@@ -336,8 +336,8 @@ prepare_rancher() {
   logged_run "rancher: helm fetch cert-manager chart" helm fetch jetstack/cert-manager --version "${Cert_Manager_Version}"
   [[ "$?" != "0" ]] && echo "helm fetch Cert_Manager failed" && exit 1
 
-  # 下載 cert-manager 要求的 CRD
-  logged_run "rancher: download cert-manager CRD" curl -L -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.crds.yaml
+  # 下載 cert-manager 要求的 CRD（-sSL：silent + show-error + follow-redirect）
+  logged_run "rancher: download cert-manager CRD" curl -sSL -o cert-manager-crd.yaml https://github.com/cert-manager/cert-manager/releases/download/"${Cert_Manager_Version}"/cert-manager.crds.yaml
   [[ "$?" != "0" ]] && echo "Download Cert_Manager CRD failed" && exit 1
 
   # 處理 cert-manager 的 Container Images
@@ -434,10 +434,11 @@ prepare_k3s() {
   # 切換工作目錄
   cd ~/work/k3s/"${K3S_Version}"
 
-  logged_run "k3s: download k3s-airgap-images-amd64.tar" curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s-airgap-images-amd64.tar
+  # -sSL：silent + show-error + follow-redirect，去掉 -# 的 hash progress bar
+  logged_run "k3s: download k3s-airgap-images-amd64.tar" curl -sSL -O https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s-airgap-images-amd64.tar
   [[ "$?" != "0" ]] && echo "Download k3s-airgap-images-amd64.tar ${K3S_Version} failed" && exit 1
 
-  logged_run "k3s: download k3s binary" curl -# -OL https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s
+  logged_run "k3s: download k3s binary" curl -sSL -O https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s
   [[ "$?" != "0" ]] && echo "Download k3s Binary File ${K3S_Version} failed" && exit 1
 
   logged_run "k3s: download install.sh" curl -sfL https://get.k3s.io/ --output install.sh

--- a/prepare.sh
+++ b/prepare.sh
@@ -68,6 +68,14 @@ Environment variables:
      定義 K3S 的版本
      預設是 'v1.35.3'。
 
+   - K3S_Revision
+     定義 K3S 的 revision 後綴
+     預設是 'k3s1'。
+
+   - K3S_Source_URL
+     定義下載 K3S airgap artifact 的來源 URL
+     預設是 'https://prime.ribs.rancher.io'（Rancher Prime Artifacts）。
+
    - Neuvector_Version
      定義 Neuvector 的版本
      預設是 '5.5.0'。
@@ -167,6 +175,16 @@ setup_env() {
   # make sure the version of the K3S is defined
   if [[ -z "${K3S_Version}" ]]; then
     K3S_Version="v1.35.3"
+  fi
+
+  # make sure the revision of the K3S is defined
+  if [[ -z "${K3S_Revision}" ]]; then
+    K3S_Revision="k3s1"
+  fi
+
+  # make sure the URL of the K3S source is defined
+  if [[ -z "${K3S_Source_URL}" ]]; then
+    K3S_Source_URL="https://prime.ribs.rancher.io"
   fi
 
   # make sure the version of the Neuvector is defined
@@ -493,10 +511,10 @@ prepare_k3s() {
   cd ~/work/k3s/"${K3S_Version}"
 
   # -sSL：silent + show-error + follow-redirect，去掉 -# 的 hash progress bar
-  logged_run "k3s: download k3s-airgap-images-amd64.tar" curl -sSL -O https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s-airgap-images-amd64.tar
+  logged_run "k3s: download k3s-airgap-images-amd64.tar" curl -sSL -O "${K3S_Source_URL}"/k3s/"${K3S_Version}"%2B"${K3S_Revision}"/k3s-airgap-images-amd64.tar
   [[ "$?" != "0" ]] && echo "Download k3s-airgap-images-amd64.tar ${K3S_Version} failed" && exit 1
 
-  logged_run "k3s: download k3s binary" curl -sSL -O https://github.com/k3s-io/k3s/releases/download/"${K3S_Version}"%2Bk3s1/k3s
+  logged_run "k3s: download k3s binary" curl -sSL -O "${K3S_Source_URL}"/k3s/"${K3S_Version}"%2B"${K3S_Revision}"/k3s
   [[ "$?" != "0" ]] && echo "Download k3s Binary File ${K3S_Version} failed" && exit 1
 
   logged_run "k3s: download install.sh" curl -sfL https://get.k3s.io/ --output install.sh

--- a/prepare.sh
+++ b/prepare.sh
@@ -49,7 +49,11 @@ Environment variables:
 
    - Rancher_Version
      定義 Rancher 的版本
-     預設是 'v2.14.0'。
+     預設是 'v2.13.4'。
+
+   - Rancher_Source_URL
+     定義下載 Rancher airgap artifact 的來源 URL
+     預設是 'https://prime.ribs.rancher.io'（Rancher Prime Artifacts）。
 
    - Helm_Version
      定義 Helm 的版本
@@ -141,7 +145,12 @@ setup_env() {
 
   # make sure the version of the Rancher is defined
   if [[ -z "${Rancher_Version}" ]]; then
-    Rancher_Version="v2.14.0"
+    Rancher_Version="v2.13.4"
+  fi
+
+  # make sure the URL of the Rancher source is defined
+  if [[ -z "${Rancher_Source_URL}" ]]; then
+    Rancher_Source_URL="https://prime.ribs.rancher.io"
   fi
 
   # make sure the version of the Helm is defined
@@ -285,7 +294,7 @@ prepare_rancher() {
   # 下載 Rancher Images List 文字檔及蒐集 Image 所需的 Shell Script
   for x in rancher-images.txt rancher-load-images.sh rancher-save-images.sh
   do
-    wget -q https://github.com/rancher/rancher/releases/download/"${Rancher_Version}"/"${x}" &>> "${Command_Output_log_file}"
+    wget -q "${Rancher_Source_URL}"/rancher/"${Rancher_Version}"/"${x}" &>> "${Command_Output_log_file}"
     [[ "$?" != "0" ]] && echo "Download ${x} failed" && exit 1
   done
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                              
                                                                                                                                                                                                          
  21 個 commit 的批次改進，可分為七個主題：                                                                                                                                                               
   
  ### 1. Rancher Prime Artifacts 切換（統一官方鏡像來源）                                                                                                                                                 
  - `1f00eb0`、`e407c64`、`f2f89f1`、`6acb102` — RKE2 / Rancher / K3S 的 artifact 下載從 GitHub releases 切到 `https://prime.ribs.rancher.io`，新增對稱的 `*_Source_URL` 與 `*_Revision` env
  var，預設版本對齊 Prime 上實際存在的版本（e.g. Rancher v2.13.4、RKE2 v1.35.3+rke2r3、K3S v1.35.3+k3s1）。                                                                                               
                                                         
  ### 2. 結構化 log 與螢幕輸出體驗                                                                                                                                                                        
  - `0c14398`、`3debeaa`、`b7504c5` — 新增 `logged_run` / `log_section` helper，把 ~40 個 pull/wget/curl/helm/save/tar 呼叫包起來；合併 log 檔為 `=== [TS] <label> ===` / `CMD:` / output / `EXIT:`
  結構化區塊，每個 `prepare_*` 首尾 `############` 分隔;;;`PS4` 調整讓 xtrace 帶時間戳＋行號。                                                                                                            
  - `e69b40d` — pull loop 加 per-image 進度列 `[<batch> N/M] <image>`，走 `/dev/tty` 不污染 log。
  - `8a5c00d` — wget dots / curl `-#` 的 progress 用 `-nv` / `-sSL` 抑制（rancher 127 個 image 從 14k 行 log → 30 行）。                                                                                  
                                                                                                                                                                                                          
  ### 3. Helm 版本相容性                                                                                                                                                                                  
  - `a529832` — `helm fetch` → `helm pull`（v4 移除 fetch alias）。                                                                                                                                       
  - `3ee5ec8` — `setup_env` 加 pre-flight n-3 skew check：按 `Helm 3.N → k8s 1.(N+15)` 規律檢查 `${Helm_Version}` 與 `${RKE2_Version}`／`${K3S_Version}` 是否相容，不合就 exit 1 並印操作提示。 (ref:     
  https://helm.sh/docs/topics/version_skew/)                                                                                                                                                              
                                                                                                                                                                                                          
  ### 4. Dispatch 強化                                                                                                                                                                                    
  - `7f05b42` — 新 `run_step` wrapper 用 `PIPESTATUS[0]` 修正 `prepare_* | tee` pipeline subshell 吞掉 `exit 1` 的老問題;`all` target 擴充為 5 個產品（harbor → rke2 → rancher → k3s → neuvector）。
                                                                                                                                                                                                          
  ### 5. 執行冪等性
  - `27f87d7` — 每個 `prepare_*` 開頭 `rm -f ~/work/compressed_files/<product>-*.tar.gz`，同產品 tarball 不會累積歷史版本。                                                                               
  - `9ed5fd4` — wget 加 `-O <filename>` 顯式覆寫同名檔，避免重跑時產生 `*.1` 累積（嚴重時會讓 rancher-images.txt 被誤 sort 成前次內容，打包出靜默失準的 tarball）。                                       
                                                                                                                                                                                                          
  ### 6. 粗糙處清理 & 新功能                                                                                                                                                                              
  - `5c14d3e` — 修 `${Command}` vs `$command` typo、`podman save` 缺 `-m`、prepare.sh 的 `{K3S_Version}` 漏 `$`、cert-manager helm template 重跑消除。                                                    
  - `77402b7` — 新增 `cert-manager.yaml`（combined install manifest）下載，供離線端直接 `kubectl apply` 路徑使用。                                                                                        
  - `1a6364a` — 全產品預設版本升級到當時 stable latest。                                                                                                                                                  
                                                                                                                                                                                                          
  ### 7. 文件                                                                                                                                                                                             
  - `ed5779c` — 新增 CLAUDE.md（回覆語言規範、GitOps 原則、架構、已知粗糙處）。                                                                                                                           
  - `a6b0f78` — CLAUDE.md 移除已解決的粗糙處記錄。                                                                                                                                                        
  - `3248800`、`bb6bce7` — README 對齊現況（Prerequisites 加 `nc`、`all` 描述擴充、Log 段落重寫說明結構化格式、Helm↔k8s 版本相容性章節、Example 版本對齊並新增 K3S/Helm/cert-manager 覆寫示範）。         
                                                                                                                                                                                                          
  ## Test plan                                                                                                                                                                                            
                                                                                                                                                                                                          
  - [x] `bash -n prepare.sh && bash -n podman-prepare.sh` 語法通過                                                                                                                                        
  - [x] `./podman-prepare.sh harbor` 實機跑完，產出 661 MB tarball，log 結構符合預期
  - [x] `helm_version_skew_check` 五個測試情境（預設、太舊、太新、邊界、v4）行為都對                                                                                                                      
  - [x] 重跑 harbor 驗證 `-O` 修正無 `*.1` 累積                                                                                                                                                           
  - [ ] `./podman-prepare.sh rancher` 實機驗證（需網路 + rancher chart 存在於 Prime v2.13.4）                                                                                                             
  - [ ] `./podman-prepare.sh rke2` 實機驗證                                                                                                                                                               
  - [ ] `./podman-prepare.sh k3s` 實機驗證                                                                                                                                                                
  - [ ] `./podman-prepare.sh neuvector` 實機驗證                                                                                                                                                          
  - [ ] `./podman-prepare.sh all` 端對端驗證（跑滿全部五個產品）                                                                                                                                          
                                                                                                                                                                                                          
  🤖 Generated with [Claude Code](https://claude.com/claude-code)